### PR TITLE
🤖 Add the core skills migrated from `hora-skills`

### DIFF
--- a/kit/skills/core/hc-accessors/SKILL.md
+++ b/kit/skills/core/hc-accessors/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: hc-accessors
+description: "Conventions for class accessor (getter/setter) definitions: setters are prohibited for immutability; `#get:Ctor` is reserved for `this.constructor`; dependency references are extracted into getters — a static `[TargetClassName]Ctor` for classes to instantiate, or a plain instance getter for non-instantiated dependencies like native modules; getter bodies forbid branching and method calls, staying pure property references."
+---
+
+# Classes: Members / Accessors
+
+This summarizes conventions related to class accessor (getter / setter) definitions.
+
+## Setters are prohibited
+
+- Do not define setters (`set xxx () {}`).
+- Reason: this codebase implements all classes as immutable (properties are set once in the constructor and never
+  reassigned). A setter would allow reassignment after creation, breaking the premise of immutability.
+- When you want to change state, instead of rewriting via a setter, generate a new instance via a factory method (see "Classes are immutable / property reassignment is prohibited" in the property-definition convention).
+- Exception: for arguments passed to `Proxy` (such as the handler in `new Proxy(target, handler)`), a `set` trap may
+  be defined as needed. This is not a reassignment of a class property but the definition of `Proxy` behavior, and
+  does not conflict with the intent of immutability.
+
+## Reserve `#get:Ctor` as a conventional getter
+
+- `#get:Ctor` is reserved as the conventional getter that "returns `this.constructor`."
+  (For usage, type resolution, and override details, see the scope-reference convention.)
+- Therefore, do not use the name `Ctor` as a member name for any other purpose.
+
+## Extract references to dependency modules into a getter
+
+- When a module (the class itself) depends on another module — whether a native module, a third-party module, or an in-house module — do not use the reference to that dependency directly as the imported identifier. **Extract it into a getter.**
+- Reason:
+  - **Easy patching**: if the dependency module has a bug and needs an emergency patch, it suffices to override the getter in a subclass; call sites do not need to change.
+  - **Easy mocking**: in tests, swapping the getter is enough to replace the dependency module entirely.
+- When the dependency is a **class to be instantiated** via `new` / `.create(...)`, extract it into a static getter named `[TargetClassName]Ctor` per the next section, and instantiate via a dedicated factory method (see "Instantiate dependency classes via a factory method" in the method-definition convention).
+
+```javascript
+// NG: using a dependency class directly
+import Aggregator from './Aggregator.js'
+
+export default class BaseRewardCalculator {
+  constructor ({
+    config,
+    aggregator,
+  }) {
+    this.config = config
+    this.aggregator = aggregator
+  }
+
+  static create ({
+    config,
+  } = {}) {
+    const aggregator = Aggregator.create({ config }) // NG: instantiated directly
+
+    return new this({
+      config,
+      aggregator,
+    })
+  }
+}
+```
+
+```javascript
+// OK: extract into a static getter named [TargetClassName]Ctor, and instantiate via a dedicated factory method
+import Aggregator from './Aggregator.js'
+
+export default class BaseRewardCalculator {
+  constructor ({
+    config,
+    aggregator,
+  }) {
+    this.config = config
+    this.aggregator = aggregator
+  }
+
+  static create ({
+    config,
+  } = {}) {
+    const aggregator = this.createAggregator({ config }) // OK: via a dedicated factory method
+
+    return new this({
+      config,
+      aggregator,
+    })
+  }
+
+  static get AggregatorCtor () {
+    return Aggregator
+  }
+
+  static createAggregator ({
+    config,
+  }) {
+    return this.AggregatorCtor.create({ config })
+  }
+}
+```
+
+- When applying an emergency patch in a subclass, overriding `AggregatorCtor` alone suffices.
+
+```javascript
+// OK: swapping in the patched class only requires overriding AggregatorCtor
+import PatchedAggregator from './PatchedAggregator.js'
+
+export default class UserRewardCalculator extends BaseRewardCalculator {
+  /** @override */
+  static get AggregatorCtor () {
+    return PatchedAggregator
+  }
+}
+```
+
+## Static getters holding a constructor used for delegation should be named `[TargetClassName]Ctor`
+
+- When holding a target class's constructor in a static getter for delegation purposes, the getter name should be "**target class name + `Ctor`**".
+- Example: for the `Constraint` class's constructor → `.get:ConstraintCtor`; for `Client` → `.get:ClientCtor`.
+- When the target class is undetermined, such as in an abstract base class, a generic name expressing the role (e.g. `TargetCtor`) is fine.
+
+```javascript
+// OK: static getter holding the constructor of the delegate target class ([TargetClassName]Ctor)
+static get ConstraintCtor () {
+  return SampleConstraint
+}
+```
+
+## Native modules and other dependencies that involve no instantiation are returned as-is via an instance getter
+
+- When the dependency is a native module such as `fs` — where the module itself is the value and there is no instantiation via `new` / `.create(...)` — neither the `Ctor` suffix nor a dedicated factory method is needed. Define a single **instance getter** that returns the dependency module as-is.
+- Calling a function of the module from within the getter is prohibited, per the "do not call a method from a getter" convention. The getter must return nothing but the module reference itself.
+
+```javascript
+// OK: an instance getter that returns a native module as-is
+import fs from 'fs'
+
+export default class DeepLoader {
+  get fs () {
+    return fs
+  }
+
+  collectFileNames ({
+    poolPath = this.poolPath,
+  } = {}) {
+    return this.fs.readdirSync(poolPath)
+      .filter(it => !it.startsWith('.'))
+  }
+}
+```
+
+## Do not write branching inside a getter
+
+- Do not write **branching** (`if` statements, ternary operators, etc.) in the body of a getter.
+- One of a getter's responsibilities is **drilling down into properties** to resolve the Law of Demeter. Confine deep property chains within the getter, keeping the caller shallow.
+- A getter must not return `undefined`. When a value cannot be obtained, resolve it to `null` with `?? null`.
+  - This `??` is itself a kind of branching, but since the condition is limited solely to "identifying `undefined`," it is permitted as an exception.
+- When drilling down into properties, treat `this.xxxx` as the receiver, and follow "one property chain per line" from the coding-styles convention. That is, chop it down so that there is **at most one receiver per line, and at most one property call per line**.
+
+```javascript
+// OK: this.entity is the receiver, one property per line. undefined is resolved to null with ?? null
+get authorId () {
+  return this.entity.comment
+    ?.author
+    ?.id
+    ?? null
+}
+```
+
+- When drilling down into properties, if **the leading lines of the chain recur across multiple getters**, extract that leading part into a separate getter. The subsequent getters then continue using the extracted getter as their receiver.
+
+```javascript
+// NG: the leading `this.entity.comment ?.author` is duplicated across multiple getters
+get authorId () {
+  return this.entity.comment
+    ?.author
+    ?.id
+    ?? null
+}
+
+get authorName () {
+  return this.entity.comment
+    ?.author
+    ?.name
+    ?? null
+}
+
+// OK: extract the common leading part into a getter, and use it as the receiver from then on
+get author () {
+  return this.entity.comment
+    ?.author
+    ?? null
+}
+
+get authorId () {
+  return this.author?.id
+    ?? null
+}
+
+get authorName () {
+  return this.author?.name
+    ?? null
+}
+```
+
+## Do not call a method from a getter
+
+- Do not **call a method** from the body of a getter. The receiver does not matter: `this.xxxx()`, `this.Ctor.xxxx()`, a method on an object reached by drilling down, and a global function are all prohibited.
+- Reason: from the caller's side, a getter looks like a **property access** (`this.authorLabel`). Calling a method behind it makes it **implicit, from the caller's side, that processing is running**. What looks like a property must be complete as a property reference alone.
+- A getter's responsibility is limited to the property drilling of the previous section. When processing is needed, define it as a method and let the caller call it as a method.
+
+```javascript
+// NG: calling a method from a getter. The caller's this.authorLabel looks like a property, yet formatting runs behind it
+get authorLabel () {
+  return this.buildLabel(this.author)
+}
+
+// OK: keep the getter to a property reference, and let the caller call the formatting as a method
+get author () {
+  return this.entity.comment
+    ?.author
+    ?? null
+}
+
+buildAuthorLabel () {
+  return this.buildLabel(this.author)
+}
+```
+
+- When the value reached by drilling down is a function, **returning it without calling it** is out of scope. What is prohibited is calling within the getter; returning a function as a value is not restricted.
+- Exception: an abstract getter that requires an override and declares itself unimplemented via `throw new Error()` is out of scope. Its format follows the error-handling convention.

--- a/kit/skills/core/hc-async/SKILL.md
+++ b/kit/skills/core/hc-async/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: hc-async
+description: "Conventions for writing asynchronous code. When writing Promises, use async/await whenever possible."
+---
+
+# Shared: Async
+
+Conventions related to writing asynchronous code.
+
+## Promise
+
+- When writing Promises, use `async`/`await` whenever possible.

--- a/kit/skills/core/hc-charters-coding/SKILL.md
+++ b/kit/skills/core/hc-charters-coding/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: hc-charters-coding
+description: "ORT coding charter. Write readable, unified code; avoid modification; let the code explain everything."
+---
+
+# ORT Coding Charter ⛩️
+
+The coding charter for ORT development. It aims to minimize the reader's burden while maximizing maintainability and AI learning efficiency.
+
+## (1) Neither Quirk Nor Quiz
+
+- Don't write quiz-like code that forces readers to rack their brains, nor unique, unconventional, show-off code.
+- Write simple, unified code that anyone can easily understand.
+
+## (2) Writing Once, Reading Unlimited
+
+- Code is written to be read by others. Hiding information out of laziness only increases the reader's effort.
+- Our job is to write code, not to omit it. Syntactic sugar is the furthest thing from our values.
+- However, widely adopted and established constructs — such as `class` (sugar over prototype inheritance) or `async`/`await` (broadly, sugar over Promises) — are not regarded as syntactic sugar. For constructs whose "sugar-ness" differs between the broad and narrow senses, use only those approved on a whitelist.
+
+## (3) Write Code Like Carving on a Slab
+
+- Once written, code should be modified as little as possible. Overlooking an affected area leads to hard-to-find bugs.
+- If a feature can be added without touching existing code, bugs are confined to the "added code." Learn the Open-Closed Principle and design as if carving into a slab.
+
+## (4) Let the Code Explain All
+
+- Don't write code that relies on implicit understanding or undocumented assumptions. Give the reader all the information needed to understand its purpose and functionality.
+- `t()` tells us nothing; `i18n.t()` gives at least a basic sense of what it does.
+
+## (5) Write Code You Can Justify
+
+- The PR author is responsible for justifying their code, able to explain every line when asked "why this logic?".
+- Unacceptable: "I wrote it as told", "I pasted AI output as-is", "it seemed to work", "I reused existing code without understanding it".
+
+## (6) Count Spaces as Code
+
+- Here, "spaces" means half-width spaces and blank lines. Treat them as spaces that contain code, not gaps between code.
+- Spaces clarify structure and reduce the reader's burden. Don't omit blank lines to save keystrokes.
+
+## (7) Vertical is Better than Horizontal
+
+- Prefer vertical code over horizontal. Long lines force horizontal scrolling and disrupt reading flow; the human eye is not accustomed to reading horizontally separated information.
+- Examples: don't pack multiple lines into one; break method chains one by one; put each ternary term on its own line; prefer more records over more DB columns; put each HTML attribute on its own line.
+
+## (8) Keep Everything One by One
+
+- Making the reader extract multiple pieces of information from one piece of code is a trap for oversight. Narrow information down to one to reduce the reader's burden.
+- Examples: one expression per line; don't nest if statements; one responsibility per method; one concept per class; break `))` between the two characters; RDB normalization; one purpose per PR.
+
+## Version
+
+- v1: 2025/04/03

--- a/kit/skills/core/hc-classes-constructor/SKILL.md
+++ b/kit/skills/core/hc-classes-constructor/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: hc-classes-constructor
+description: "Conventions for class constructors. Constructor parameters must not have default values."
+---
+
+# Classes: Constructor
+
+Conventions related to class constructors.
+
+## Do not assign default values to parameters
+
+- Do not assign default values to constructor parameters.
+
+```javascript
+// NG: assigning a default value to a parameter
+constructor ({
+  delimiter = ',',
+}) {
+  this.delimiter = delimiter
+}
+
+// OK: no default value
+constructor ({
+  delimiter,
+}) {
+  this.delimiter = delimiter
+}
+```

--- a/kit/skills/core/hc-classes-inflators/SKILL.md
+++ b/kit/skills/core/hc-classes-inflators/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: hc-classes-inflators
+description: "Convention for class inflator methods (binding methods). Defines the pattern of binding the class passed as an argument and returning a derived subclass memoized via BoundCtorRegistry, along with its naming (.as / .use / .to / .of / .from / .via / .each / .by / .with / .for / .on / .onto / .into), arguments, and the policy for overriding abstract members."
+---
+
+# Classes: Inflators
+
+This summarizes conventions related to inflator methods (binding methods).
+
+## What is an inflator method
+
+- An **inflator method** is a static method that binds the class passed as an argument (= binding) and returns a **memoized derived subclass**.
+- The returned derived subclass is one where the base class's **abstract member has been overridden** to return the binding.
+- "The same combination of bindings returns the same derived class" (memoization) is the core of this pattern.
+- The implementation is delegated to `BoundCtorRegistry` (`lib/tools/BoundCtorRegistry.js`). Do not cache derived classes yourself.
+
+```javascript
+export default class UnionScalar extends BaseScalar {
+  // Inflator method: binds the passed schemas and returns a memoized derived subclass
+  static of (...schemas) {
+    const registry = BoundCtorRegistry.create({
+      BaseCtor: this,
+    })
+
+    return registry.ensureBoundCtor({
+      bindings: schemas,
+      deriver: ({ Ctor }) => class extends Ctor {
+        /** @override */
+        static get boundSchemas () {
+          return schemas
+        }
+      },
+    })
+  }
+
+  // from delegates to of
+  static from (schemas) {
+    return this.of(...schemas)
+  }
+
+  // abstract member overridden by the inflator
+  /** @abstract */
+  static get boundSchemas () {
+    throw new Error(`${this.name}.get:boundSchemas must be inherited`)
+  }
+}
+```
+
+## Define the inflator as a static method on the target class being bound itself
+
+- An inflator method should be defined as a **static method on the target class being bound itself**, not as an external utility.
+- Unless there is a specific reason otherwise, pass **`this`** as `BaseCtor` in `BoundCtorRegistry.create({ BaseCtor })`.
+  - By passing `this`, even when the inflator is called from an inheriting subclass, the derived class is generated based on that subclass (respecting the inheritance chain).
+  - Hardcoding the class name (`BaseCtor: UnionScalar`) would always anchor to the base class even when called from a subclass, breaking polymorphism.
+
+```javascript
+// NG: hardcoding the class name in BaseCtor
+static of (...schemas) {
+  const registry = BoundCtorRegistry.create({
+    BaseCtor: UnionScalar, // ❌️ anchors to UnionScalar even when called from a subclass
+  })
+  // ...
+}
+
+// OK: this for BaseCtor
+static of (...schemas) {
+  const registry = BoundCtorRegistry.create({
+    BaseCtor: this,
+  })
+  // ...
+}
+```
+
+- Exception: the **graft family** described later (`.onto()` / `.into()`) intentionally puts `BaseCtor` on the argument side (the direction is reversed).
+
+## Values bound must be objects
+
+- The value (binding) passed to and bound by an inflator **must be an object**. Primitives (strings, numbers, booleans, etc.) cannot be bound.
+- Reason: `BoundCtorRegistry` uses the binding as a **WeakMap key** for memoization. WeakMap keys are restricted to objects (and Symbols).
+- What is actually bound is typically a class (constructor = a function object), a schema object, or a config object, so this constraint is naturally satisfied.
+
+## Memoization semantics
+
+- The granularity of memoization is the **combination of `bindings` (i.e. reference identity of the objects)**. The same binding returns the same derived class.
+
+```javascript
+UnionScalar.of(A, B) === UnionScalar.of(A, B) // true (same binding → same class)
+UnionScalar.of(A, B) === UnionScalar.of(A, C) // false (different binding → different class)
+```
+
+- The derived class inherits from the base and **retains the base class's name** (`BoundCtorRegistry` names it with `{ [BaseCtor.name]: class extends ... {} }`).
+
+```javascript
+const Bound = OriginalCtor.use(FirstConstraint)
+
+Bound.prototype instanceof OriginalCtor // true
+Bound.name // 'OriginalCtor'
+```
+
+- Since inflators are memoized, they are **safe to call every time**. There's no need for the caller to store the
+  inflator's return value in a variable to cache it.
+
+```javascript
+// OK: it is fine to inflate on every call (memoization prevents wasteful creation)
+inflateMessageCtor () {
+  return this.MessageCtor
+    .use(this.MessageDeserializerCtor)
+    .toKey(this.MessageKeyCtor)
+    .toValue(this.MessageValueCtor)
+}
+```
+
+- **Design philosophy**: if you want to share the same derived class, **pass the same reference**. In particular, with `.by()`, which passes an object literal, if there is an intent to reuse it, make sure to implement it so the same reference is passed. Passing a disposable (one-off) temporary object each time is acceptable (once the key is released it is removed from the WeakMap and does not leak).
+
+## Override abstract members in inflators
+
+- In the derived class returned by `deriver`, **override the base's abstract member** to return the binding.
+- When the overridden target is "a getter that holds the constructor of the delegate target class," name that getter `[TargetClassName]Ctor` (see "static getter holding the constructor used for delegation" in the accessor-definition convention). If the target is an undetermined abstract target, a generic name expressing the role (e.g. `TargetCtor`) is fine.
+- Annotate overrides with `/** @override */`.
+
+```javascript
+// OK: overriding an abstract static getter within deriver ([TargetClassName]Ctor naming)
+deriver: ({ Ctor }) => class extends Ctor {
+  /** @override */
+  static get MessageKeyCtor () {
+    return MessageKeyCtor
+  }
+}
+```
+
+## Pass arguments flat
+
+- Inflator methods do not use a named-argument object (`({ ... })`); they receive the arguments to pass **flat** (an **exception** to "arguments should be a single named-argument object" in the method-definition convention).
+- Basically **a single argument**. Only use multiple/array arguments when dealing with variadic or array input.
+  - Single argument: `use(ConstraintCtor)` / `as(Schema)` / `toKey(MessageKeyCtor)`
+  - Variadic: `of(...Ctors)`
+  - Single array: `from(Ctors)` (`from` delegates to `of`)
+- Reason: this is so calls read **declaratively**, as in `Document.as(bindingSchema)` or `UnionScalar.of(A, B)`.
+- **Exception**: as with `.by()`, when the value being bound is **configuration / arguments**, it is acceptable to pass a named-argument object (`Record<string, *>`) as that value (since the value is an object, it also satisfies the WeakMap key constraint).
+
+```javascript
+// NG: wrapping in a named-argument object
+static use ({ ConstraintCtor }) { /* ... */ }
+
+// OK: flat single argument
+static use (ConstraintCtor) { /* ... */ }
+
+// OK: variadic / array argument
+static of (...Ctors) { /* ... */ }
+static from (Ctors) {
+  return this.of(...Ctors)
+}
+
+// OK (exception): binding of config/argument can take a named-argument object as its value
+static by (argument) { /* argument: Record<string, *> */ }
+```
+
+## Naming convention (short, preposition-like names)
+
+Inflator methods are given short, preposition-like names so that `Receiver.word(binding)` reads declaratively. Each word expresses "the relationship between the receiver and the binding." The vocabulary is classified into three families.
+
+### Absorption family (forward direction, result is receiver family)
+
+The receiver absorbs / becomes / uses the binding. `BaseCtor: this`, result is receiver family.
+
+| Method | Semantics | Arguments | Example |
+| :-- | :-- | :-- | :-- |
+| `.as()` | The binding **matches the identity of the whole class** (becomes that thing itself) | Single | `NodeScalar.as(Constraint)` / `ResponseBody.as(schema)` |
+| `.use()` | Binds an **auxiliary used internally** by the receiver (Deserializer / Constraint, etc.) — broad sense | Single | `ConsumerMessage.use(JsonMessageDeserializer)` |
+| `.for()` | A narrow sense of `.use()` — the binding is the **target/purpose of specialization** (works "for" something) | Single | `Logger.for(BaseResolverCtor)` |
+| `.on()` | A narrow sense of `.use()` — the binding is the **target/trigger of action** (works "on" something) | Single | `Handler.on(ClickEvent)` |
+| `.by()` | Binds **input-side** config / argument (acts before the main behavior) | Single (object allowed) | `Converter.by({ precision: 2 })` |
+| `.to()` | Binds a **Converter class** (the counterpart of conversion) | Single | `ConsumerMessage.to(Converter)` |
+| `.of()` | Binds multiple Ctors **with an ordering (sequence)** | Variadic | `UnionScalar.of(A, B)` |
+| `.from()` | **Syntactic sugar** for `.of()` (accepts a single array and delegates to `.of()`) | Single array | `UnionScalar.from([A, B])` |
+| `.via()` | Applies the binding to **part of the whole schema** | Single | — |
+| `.each()` | Applies one definition to **multiple locations (each element)** (a variant of `.via()`) | Single | `RecordScalar.each(valueSchema)` |
+| `.with()` | **Output-side** — binds an accompanying object that **manipulates the output** (acts after the main behavior) | Single | `HttpClient.with(RetryPolicy)` |
+
+- **When there are multiple Converters, distinguish them with an object suffix**: `.toKey()` / `.toValue()` (e.g. `ConsumerMessage.toKey(K).toValue(V)`).
+
+### Graft family (reverse direction, result is argument family)
+
+With `Alpha.word(Beta)`, the receiver (Alpha) is not inflated; instead, **the receiver is grafted/injected onto the argument (Beta) side**. The roles of `BaseCtor` and `bindings` are swapped, and the result becomes the **argument family**.
+
+| Method | Semantics | Example |
+| :-- | :-- | :-- |
+| `.onto()` | `Alpha.onto(Beta)` — **places** Alpha onto Beta (graft). The result is Beta family | — |
+| `.into()` | `Alpha.into(Beta)` — **injects** Alpha into Beta (inject / embed). The result is Beta family | — |
+
+```javascript
+// Graft family: argument for BaseCtor, this for bindings (roles reversed)
+static onto (TargetCtor) {
+  const registry = BoundCtorRegistry.create({
+    BaseCtor: TargetCtor, // ← inflate based on the argument side
+  })
+
+  return registry.ensureBoundCtor({
+    bindings: [
+      this, // ← the receiver itself becomes the binding
+    ],
+    deriver: ({ Ctor }) => class extends Ctor {
+      /** @override */
+      static get boundSource () {
+        return this
+      }
+    },
+  })
+}
+```
+
+### How to choose a word
+
+- Read `Receiver.word(binding)` as English and choose the word that most naturally expresses the "relationship." If it improves declarative readability, prefer a narrow-sense word (`.for()` / `.on()`) over the broad-sense `.use()`.
+- Decision rule when in doubt:
+  1. **Is the result you want receiver family or argument family?** If argument family (you want to place the receiver onto the argument), use the graft family (`.onto()` / `.into()`).
+  2. If forward direction, choose a word from the absorption family based on **absorb/become/use** for the binding.
+     - **Becomes the binding itself** → `.as()`
+     - **A tool used internally** → `.use()` (`.for()` if it's a specialization purpose, `.on()` if it's a target of action)
+     - **Input-side config** → `.by()` / **output-side manipulation** → `.with()`
+     - **Counterpart of conversion** → `.to()` (`.toKey()` / `.toValue()` for multiple)
+     - **Multiple with an ordering** → `.of()` (`.from()` for an array)
+     - **Applied to a part/each location** → `.via()` / `.each()`
+
+## Chaining
+
+- Multiple inflators can be **chained**. Since each inflator returns a derived subclass, the next inflator can be called on its return value.
+
+```javascript
+// OK: chaining use → toKey → toValue to obtain a derived class with three bindings bound together
+const MessageCtor = ConsumerMessage
+  .use(JsonMessageDeserializer)
+  .toKey(SampleMessageKey)
+  .toValue(SampleMessageValue)
+```

--- a/kit/skills/core/hc-classes-notations/SKILL.md
+++ b/kit/skills/core/hc-classes-notations/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hc-classes-notations
+description: "Convention for the order members are written in a class body — the eight-block placement order (fields, constructor, factory methods, inflators, getters, methods) plus the ordering within getters and within methods, falling back to source order where undetermined. What a class may hold belongs to the class design principles convention; this covers only writing order. Refer to it when arranging or reviewing member order."
+---
+
+# Classes: Notations
+
+Collects the conventions for how a class definition is written in source. Design-level judgments — what a class may hold, what it must not use — are governed by the class design principles convention; this skill establishes only the **way it is written**.
+
+## Placement order of members
+
+Write a class body in the following order.
+
+1. `static` fields
+2. `constructor`
+3. The factory methods (`.create()` → `.createAsync()`)
+4. static inflator methods
+5. static getters
+6. static methods
+7. instance getters
+8. instance methods
+
+Item 3 means the class's own factory methods that are published as API. The convention of placing `.create()` immediately after the `constructor` is governed by the method-definition convention, and the definition and naming of the inflator methods in item 4 by the inflator-methods convention.
+
+### Why `static` fields go at the top
+
+- This follows the Java convention.
+- **The order is arranged to mirror the order in which memory is secured.** `static` fields are secured and
+  initialized at class-definition time, and an instance's properties are secured afterwards in the `constructor`.
+  Matching the source order to that order makes the order of allocation readable by simply reading the source from top
+  to bottom.
+- The conditions for using `static` fields, and what belongs in them (do not use `static #X`; put accumulating associations, pools, and caches in `static` + `WeakMap`, etc.), are governed by the class design principles convention.
+
+### Order among getters
+
+Within the getter categories (5 and 7), use the following order.
+
+1. Getters that return a fixed value. Among them, place the ones denoted by `~Ctor` (static getters for delegation) first.
+2. The rest (getters that compute the value they return).
+3. List abstract getters last, together.
+
+The naming of `~Ctor` is governed by the accessor-definition convention.
+
+### Order among methods
+
+Within the method categories (6 and 8), the order is **the order of appearance in an outline that writes out the nesting structure of calls**. Immediately after a method, place the methods that it calls (depth-first, first appearance). Members belonging to another category (getters and the like), and anything that is not an own member of the class (methods of a delegate or of a dependency class), are left out of this enumeration.
+
+**For instance methods, the call outline of the private methods takes priority.** Therefore abstract members are not collected and placed at the end; they go at their first-appearance position in the outline.
+
+An outline example for a `Sample` class.
+
+```
+// --- Static Methods ---
+
+- .create()
+  - constructor
+
+- .createAsync()
+  - .buildAlpha()
+  - .generateBeta()
+  - .createAlphaClient()
+  - .create()
+
+- .buildAlpha()
+  - .get:AlphaCtor
+
+- .generateBeta()
+  - .buildGamma()
+
+- .buildGamma()
+  - .get:delta
+
+- .createAlphaClient()
+  - AlphaClient.create()
+
+// --- Instance Methods ---
+
+- #buildAlpha()
+  - #generateBeta()
+  - .get:beta
+  - #defineDelta()
+
+- #generateBeta()
+  - #normalizeBeta()
+  - #defineGamma()
+  - .get:gamma
+
+- #defineGamma()
+  - #alphaClient.saveDelta()
+
+- #defineDelta()
+  - #alphaClient.loadDelta()
+```
+
+The class that corresponds to the outline above. Member bodies are folded into `{ ... }` and arguments into `(...)`, written on a single line.
+
+```javascript
+export default class Sample extends BaseSample {
+  // static field
+  static pool = new WeakMap()
+
+  constructor (...) { ... }
+
+  // factory methods
+  static create (...) { ... }
+  static async createAsync (...) { ... }
+
+  // static inflator method
+  static as (...) { ... }
+
+  // static getters
+  static get AlphaCtor () { ... }
+  static get beta () { ... }
+  static get gamma () { ... }
+  /** @abstract */
+  static get delta () { throw new Error('...') }
+
+  // static methods
+  static buildAlpha (...) { ... }
+  static generateBeta (...) { ... }
+  static buildGamma (...) { ... }
+  static createAlphaClient (...) { ... }
+
+  // instance getters
+  get Ctor () { ... }
+
+  // instance methods
+  buildAlpha (...) { ... }
+  generateBeta (...) { ... }
+  /** @abstract */
+  normalizeBeta (...) { throw new Error('...') }
+  defineGamma (...) { ... }
+  defineDelta (...) { ... }
+}
+```
+
+### What the order does not determine
+
+For whatever this skill's order does not determine, use **the order in which they are written from the top within the class**. When enumerating or documenting members, follow that same order.

--- a/kit/skills/core/hc-classes-principles/SKILL.md
+++ b/kit/skills/core/hc-classes-principles/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: hc-classes-principles
+description: "Principles of class design. Establishes the overarching principle of not creating classes without properties (no-properties class), the system that underpins it (deep immutability, constructor-only, references-as-contract, etc.), and the reasons for not using #private / decorator."
+---
+
+# Classes: Principles
+
+This summarizes the principles for class property declaration and design.
+
+## Core principle: Do not create classes without properties
+
+- A class must hold at least one instance property.
+- Do not create a class that is nothing but a collection of static methods / static fields (a static-only class). Design it as a state-holding instance class, or delegate to a single-responsibility class.
+- The class prohibitions convention is the canonical source for the detailed reasons and exceptions of this prohibition (no-properties / static-only). This skill sets that as the core principle and then systematizes the surrounding design conventions on top of it.
+
+## The five points of the system (a bundle of premises)
+
+1. **Deep immutability** — Do not reassign after construction; keep nested values (e.g. instances of other immutable classes) immutable too. **The collection types Array / Set are not deep-frozen; updates (adding/removing elements) are allowed.** The reasons are that "the set of retained items" is premised on being treated as equal regardless of count, and that it also serves to support the Builder Pattern. **However, a structure that references an individual element (e.g. pulling out a single element via `array[i]`) is prohibited** — because it is a circumvention of the prohibition on mutable objects. A collection's value must always be "used all at once" (scanned/transformed/aggregated over every element as a whole). When you need to associate by object, use `WeakMap` (if you need to enumerate, hold the keys in an Array and traverse through them). Do not use `Map` (see the property-definition convention).
+2. **Property = a constructor argument of the same name** — Every property that stores a value is passed as a
+   constructor argument of the same name. This makes the set of property names a class occupies appear in the
+   constructor signature itself, so hidden fields cannot exist in principle.
+3. **Constructor-only** — Only `this.xxx = xxx` inside the `constructor` counts as a property (see "Definition of 'property'" below).
+4. **Treat references as the contract** — The published API references fix the public surface. Direct access to a member not in the references is "undocumented = outside the contract," and breaking after coupling to it is the caller's responsibility. This is the stance that **"reaching for a member outside the contract is the same as throwing a microwave at a beast"** — a use outside the contract is not the designer's responsibility.
+5. **Enumerating instances is prohibited** — Enumerating a class instance that has behavior and invariants via `Object.keys` / `Object.entries` / `for...in` / spread `{...instance}` / `Object.assign` is treated as hack code. It is a category error that treats a behavior-bearing object as a POJO/dictionary, and a clearly bad design practice that drops the prototype (methods) to make a degraded copy.
+
+### Definition of "property"
+
+- Only `this.xxx = xxx` inside the `constructor` counts as a property.
+- Do not use class fields (`x = 1`) or private fields (`#x = 1`).
+
+Reasons:
+
+- **Single manifest** — Anyone who wants to know "what does this class hold" reads only one place, the constructor
+  (and its argument signature). If class fields are allowed, then even adding a member-ordering rule of "fields go
+  first" still leaves two places to read: the leading field group and the computed `this.x =`. The real ground for
+  going as far as prohibition is not "scattered and hard to find" but that it **guarantees "strictly one location"**
+  (if it were merely "hard to find," an ordering rule would suffice, and someone would point that out).
+- **Linear, clear initialization order** — Class fields have the semantics of being initialized "right after `super()`, before the constructor body," which breeds bugs where `super()` and field initialization interleave under inheritance. Constructor-only avoids this structurally.
+- **Eliminates split-brain** — Using class fields together with the constructor falls into a double declaration of "default in a field / overridden in the constructor from an argument." The following is a property declared twice, with the field initializer killed by the constructor override — a clearly bad design practice.
+
+```javascript
+// NG: mixing default + override (split-brain)
+class Foo {
+  x = 1              // default declaration
+  constructor (x) {
+    if (x !== undefined) {
+      this.x = x     // override; the field initializer dies
+    }
+  }
+}
+```
+
+### Handling of `static` fields
+
+- **`static` fields (`static X = ...`) may be used.** The prohibition on class fields and private fields is a convention **about instance properties**, and `static` fields are out of its scope.
+- However, **do not use `static #X` (the static form of native private).**
+
+This is because none of the three grounds for the prohibition apply to `static`.
+
+- **Single manifest** — What the manifest answers is "what does an **instance** of this class hold." A `static` field is not held by any instance, so it does not damage the at-a-glance completeness of the constructor signature. And since no declaration site exists outside the class body, "strictly one location" is already satisfied the moment it is written as `static`.
+- **Initialization order** — `static` fields are initialized in source order at class-definition time, so no problem arises from the interplay of `super()` and the constructor body.
+- **Split-brain** — There is no constructor to override in, so no double declaration occurs.
+
+The reason not to use `static #X` is that the reason not to use native private (a subclass cannot read it, which blocks extension and substitution through inheritance — see the property-definition convention) holds for `static` as well, and its impact is broader: when a `static` method refers to `this.#X`, **a call through a derived class throws a TypeError.**
+
+```javascript
+// NG: a static native private cannot be used from a derived class
+class Base {
+  static #pool = new WeakMap()
+
+  static ensure (key) {
+    return this.#pool.has(key)
+  }
+}
+class Derived extends Base {}
+
+Derived.ensure(key)
+// TypeError: Cannot read private member #pool from an object whose class did not declare it
+```
+
+#### What to put in a `static` field
+
+- **Put accumulating associations, pools, and caches in `static` + `WeakMap`, not in an instance.** Placed on an instance, they participate in equality comparison and serialization as part of the value — but a cache is not a value. With `static` + `WeakMap`, (1) it sits outside the value semantics of instances, (2) it is non-enumerable and key-gated, so a party without the key cannot reach it, and (3) the author can look inside on demand with `util.inspect(Ctor, { showHidden: true })`.
+- **Do not reassign the reference itself.** Deep immutability extends to `static` as well. Only the inside of a collection may change, and that is constrained by the property-definition convention (`Map` is not used, even for `static`).
+- **Adding `static` fields does not relax the core principle of not creating classes without properties.** A `static` field is not an instance property, so a class holding only those remains prohibited as a static-only class.
+
+### Handling of derived classes
+
+- A class that has `extends` is out of scope even if it only overrides static members. The responsibility belongs to the base class.
+
+## What not to use
+
+### `#private`
+
+Under an immutable property design, **there is no work left that is unique to `#private`**. One might initially evaluate abandoning it as "the biggest cost," but within this system it is not even a cost.
+
+- **The write axis that private protected evaporates** — Private answers "who may touch it" (access control); immutability answers "can it change at all" (mutation control). Private's historical main purpose is preventing "invariants being broken by external rewrites," but under deep immutability there is not a single write to protect, inside or out. Private is the strategy of "guarding the hazard (mutable state)," immutability is the strategy of "removing the hazard itself"; with no hazard, the guard is redundant.
+- **The remaining read axis is not `#`'s job either** — The read axis splits in two. (1) Decoupling (hiding the
+  representation to refactor) is carried by references = the contract. Coupling to a member not in the references is
+  outside the contract, so the author's freedom to refactor is guaranteed by the contract without waiting for `#`. (2)
+  Secrecy (hiding the value itself, e.g. keys/passwords) is independent of immutability, but JS's `#` is not a
+  security boundary against memory dumps/debuggers, so it is not a guarantee `#` can reliably provide — that is the
+  job of a separate layer (encryption, not retaining).
+- **Debug visibility actually favors soft-private** — In Node, `#` fields appear neither in `console.log` nor in `util.inspect(obj, { showHidden: true })` (DevTools shows `#` specially, but that is a Node-specific handicap). Soft-private (`this._x`) shows up in logs with zero extra code. For an immutable value object, the `_secret` shown there is not "dirt you want to hide" but "the very state you want to see," so being visible is correct. If you want to shape it, you can curate with `[util.inspect.custom]()` (opt-in).
+- **`#` does not save the incompetent** — A user who does not respect boundaries will, even with `#`, touch public things mutably and break something elsewhere ("a lock only keeps out the honest," "a caveman cannot use a microwave"). In closed / application code, stripping visibility and straightforward description from competent users for the sake of the thin band that accidentally couples is putting the cart before the horse.
+- **Name collisions also vanish via the system** — `#`'s last redeeming value, "safety against name collisions under inheritance," vanishes for your own hierarchy via "Property = a constructor argument of the same name." Since everything that holds a value appears in the arguments = the public signature, no hidden field exists, and the inheriting side necessarily confronts it via `super({...})`. That safety is a value for "the author of the class being inherited (the base)," not something the inheriting side gains by writing `#` in its own code.
+
+Therefore soft-private (`this._x`) is visible and correct. Do not use `#private` unless a human explicitly specifies it.
+
+### `decorator`
+
+- A `decorator` adds no capability at all. It is purely syntactic sugar over a higher-order function + metadata (`@memoize method(){}` ≡ `method = memoize(method)`); everything a decorator can do can be written explicitly.
+- This policy chooses "explicitness > brevity." A decorator's real benefits (co-locating declarative metadata, reducing DI boilerplate) are ergonomics, not capability, and they sell explicitness in return. Augmentation that is implicit, mutating, and action-at-a-distance conflicts with "explicit, immutable, single manifest."
+- A field decorator attaches to a class field, so it does not fit at the syntactic level under this policy, which prohibits class fields.
+
+## Rules
+
+- A class holds at least one instance property (if it cannot, replace it with a method of a state-holding class / delegation to a single-responsibility class)
+- Properties are only `this.xxx = xxx` inside the `constructor`; class fields and private fields are not allowed
+- `static` fields are allowed (`static #X` is not); put accumulating associations, pools, and caches in `static` + `WeakMap`; do not reassign the reference
+- Every property that stores a value is received via a constructor argument of the same name; do not reassign it (deep
+  immutability). Array / Set may be updated but referencing an individual element is prohibited (always use the whole
+  at once); use `WeakMap` for association, do not use `Map`
+- Do not directly access members not in the references; do not enumerate instances
+- Do not use `#private` or `decorator` (except when a human explicitly specifies it)
+- A class that has `extends` is out of scope
+
+## Proviso
+
+- The benefits above hold only once all "five points of the system" are in place. If any one of them (especially deep immutability) is broken while the others remain, the ground for each rule collapses. The rules' legitimacy is load-bearing on one another.

--- a/kit/skills/core/hc-classes-prohibits/SKILL.md
+++ b/kit/skills/core/hc-classes-prohibits/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: hc-classes-prohibits
+description: "Convention on prohibitions in class definitions. Establishes the policy of prohibiting static-only classes and classes without properties (state), and the reasons for them."
+---
+
+# Classes: Prohibits
+
+This summarizes prohibitions in class definitions.
+
+## Static-only classes are prohibited
+
+- Classes where every member is static and instantiation is not intended (static-only classes) are prohibited.
+- Do not introduce a static-only class merely as a place to put reusable logic. First determine "the object that should own that responsibility," and design it as delegation to that object.
+
+Exception:
+
+- A case where the ancestor class is not a static-only class, and only static members are being overridden using the Template Pattern, is not considered a static-only class.
+
+Reasons:
+
+### (1) A class is the place where "state-dependent behavior" is defined
+
+- A class is the place that defines an object that behaves depending on state. A static-only class has no instance state and is never instantiated, so it does not fulfill a class's true responsibility and is merely a namespace.
+- If you just want to reuse some logic, extract it into a single-responsibility class and delegate to it (see reason (3) for details).
+
+- Static-only classes tend to invite global mutable state (module-local variables become referenceable from every static method). Shared mutable state is an anti-pattern that reduces testability, hides dependencies, and produces side effects.
+- Note that the same problem applies to mutable variables at ESM module scope, so module-level mutable state should be treated with the same design guideline.
+
+### (2) It hinders polymorphism
+
+- Since a static-only class has no instances, it cannot benefit from polymorphism.
+- This makes it hard to accommodate future implementation swaps (test doubles, cached implementations, switching between DB/in-memory, branching by configuration, etc.).
+- Since the caller is tightly coupled to the class name, extension requires modifying existing code or adding conditional branches, increasing the cost of change.
+- If there is even a slight possibility that multiple implementations will be needed, design with an instance class from the start.
+
+### (3) Static methods should be placed where the responsibility belongs
+
+- If only one class uses a given piece of logic, implement it as that class's own method (private or a regular instance method). There is no reason to extract it into a static-only class or a function.
+- If multiple classes use it and they belong to the same inheritance hierarchy, place the shared implementation in the
+  base class. Expressing it through inheritance makes the location of responsibility clearer.
+- If it does not naturally belong to an inheritance hierarchy and is shared across multiple unrelated classes, extract it into a dedicated single-responsibility class (`Validator` / `Formatter` / `Normalizer` / `Resolver`, etc.), and have each class delegate to it. This makes dependencies explicit, allows state to be held if needed, and makes extension/mocking/testing easier.
+
+### (4) It invites argument forwarding
+
+- Since static methods cannot hold state, they end up having to receive arguments they don't use themselves, purely to forward them to downstream methods.
+- An instance class can hold arguments as properties, eliminating the need to forward them around.
+
+```javascript
+// NG: static-only (beta is forwarded around by firstMethod)
+class StaticOnlyClass {
+  static entryPointMethod ({ alpha, beta }) {
+    return { first: this.firstMethod({ alpha, beta }) }
+  }
+
+  static firstMethod ({ alpha, beta }) {
+    return alpha
+      + this.secondMethod({ beta })
+  }
+
+  static secondMethod ({ beta }) {
+    return beta * 100
+  }
+}
+
+// OK: instance class (arguments held as properties)
+class InstanceClass {
+  constructor ({ alpha, beta }) {
+    this.alpha = alpha
+    this.beta = beta
+  }
+
+  static create (params) {
+    return new this(params)
+  }
+
+  entryPointMethod () {
+    return { first: this.firstMethod() }
+  }
+
+  firstMethod () {
+    return this.alpha
+      + this.secondMethod()
+  }
+
+  secondMethod () {
+    return this.beta * 100
+  }
+}
+```
+
+### (5) It increases the cost of rewriting
+
+- When changing a static class into an instance class, every call site must be rewritten.
+- Conversely, even if an instance class's design is changed to a static class, the call sites do not need modification and can continue operating as-is.
+- Therefore, designing with an instance class from the start is more resilient to change.
+
+### (6) It increases review cost
+
+- Whether the design of a static class is appropriate must be examined every time in a pull-request review.
+- If static classes are not used, this cost can be reduced to zero.
+
+## Do not create classes without properties
+
+- Do not create a class that is meant to be instantiated but sets no properties on `this` at all in its constructor (a class with no state).
+- A class is the place where "state-dependent behavior" is defined (see reason (1) of "Static-only classes are prohibited" above). A class with no state does not fulfill that responsibility and is merely a container bundling methods together.
+- If it cannot hold any properties, that is a sign that "this class has no state of its own." Implement the logic as a method of an appropriate state-holding class, or delegate it to a dedicated single-responsibility class (`Validator` / `Formatter` / `Normalizer` / `Resolver`, etc.) (following reason (3)).
+
+Exception:
+
+- A design such as an abstract base class that holds no state itself while its derived classes hold the properties (state) is not considered a class without state (treated the same as the Template Pattern).
+
+Reason:
+
+- A class with no state always behaves the same on every instantiation, so there is no point in instantiating it. It has essentially the same problems as a static-only class (becoming a namespace, argument forwarding).

--- a/kit/skills/core/hc-code-review/SKILL.md
+++ b/kit/skills/core/hc-code-review/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: hc-code-review
+description: >
+  Run a READ-ONLY, code-level review of a change and produce a findings report — specification
+  compliance against the feature's requirement definition document, correctness, and conformance
+  to the project's coding conventions. Never fixes anything. Use this skill whenever the user asks
+  to review a change or pull request before it is merged, or to verify that what was built matches
+  what was specified.
+---
+
+# Code Review
+
+A **read-only, code-level review** of an implementation. The goal is to report where the code
+does not match what was specified, where it is likely to be wrong, and where it departs from
+the project's conventions — **not to fix any of it**.
+
+The review is written to be run against a change that has a **requirement definition document**
+behind it. Without that document the first pass cannot be run; see
+[Reviewing without a requirement document](#reviewing-without-a-requirement-document).
+
+## Rules (read first)
+
+1. **Read-only. Never edit, never fix.** Inspect, run non-mutating commands, report. State the
+   fix per finding as text; do not apply it.
+2. **Every requirement id appears in the report** with a verdict, and every check category
+   appears as findings, `PASS` or `N/A` with a one-line reason. A gap must never look like
+   "nothing to report".
+3. **Leave to the linter what the linter enforces.** Run the project's lint command; report its
+   result as one line. Do not turn lint-enforced formatting into findings — that noise buries
+   the findings that matter. Where the project has no lint command, say so on that line; the
+   formatting rules then fall to the convention pass, judged against the surrounding code.
+4. **Detect, don't assume.** Read the surrounding code before judging a line. A call that looks
+   wrong is often correct against a convention you have not read yet.
+5. **Report the defect, not the taste.** A finding states what breaks, or which stated
+   convention is violated. "I would have written this differently" is not a finding.
+6. **Never claim a requirement is implemented because a file with a matching name exists.**
+   Read the code path end to end, from the entry point to the effect the acceptance criterion
+   describes.
+
+## How to run
+
+1. **Determine the target, and confirm it is not empty.** Derive the diff under review: the
+   branch against its base (`git diff <base>...HEAD`, three-dot so the base's own commits are
+   excluded), the staged change, or a named commit range. Resolve the base to a commit before
+   using it, and **check the diff is non-empty before going further** — a mistyped base produces
+   an empty diff, and every check then passes for the wrong reason. Report the target, the
+   resolved base commit and the changed-file count at the top of the report.
+2. **Locate the requirement document** for the feature. Search in this order and say which one
+   supplied it: (a) an issue or ticket referenced by the commit messages in the range, (b) a
+   path the user gave, (c) `docs/features/<feature-slug>/requirements.md` or the project's own
+   specification location, (d) ask the user. Read every requirement and its acceptance criteria
+   before reading any code.
+3. **Profile the project.** Read `package.json` (scripts, dependencies), find the entry point,
+   the configuration, the test layout and the convention set the project follows. The
+   convention pass is a check against *this project's* conventions, not against generic advice.
+4. **Run the three passes**, each against its detail file.
+5. **Run the project's lint command** and record the result as one line — or record that the
+   project has none.
+6. **Print the report** in the order given under [Output](#output).
+
+## The three passes
+
+| Pass | Question it answers | Detail file |
+| :-- | :-- | :-- |
+| A. Specification compliance | Does the code do what was specified, and only that? | [specification-compliance.md](./references/specification-compliance.md) |
+| B. Correctness | Where is this code likely to be wrong? | [correctness-checks.md](./references/correctness-checks.md) |
+| C. Convention conformance | Where does it depart from the project's conventions — and, where the project has written none, from the baseline? | [convention-checks.md](./references/convention-checks.md) |
+
+Run them in that order. Pass A decides what the change is *for*; passes B and C are read against
+that purpose. A correctness finding in code that pass A already reported as unrequested is
+worth less than the unrequested-code finding itself.
+
+## Verdicts (pass A)
+
+One verdict per requirement id, chosen against the acceptance criteria — never against the
+requirement's title alone.
+
+| Verdict | Meaning |
+| :-- | :-- |
+| `IMPLEMENTED` | Every acceptance criterion is satisfied by a code path that was read end to end |
+| `PARTIAL` | Some criteria are satisfied and others are not; name which |
+| `MISSING` | No code in the change satisfies the requirement |
+| `WITHDRAWN` | The requirement document withdrew it; no code expected |
+| `UNVERIFIABLE` | The criterion cannot be judged from the code (an environment or measurement is required); say what would be needed |
+
+Code in the change that satisfies no requirement is not a verdict — it is reported as an
+`UNREQUESTED` finding in pass A, because unrequested behavior is the failure mode a
+specification-compliance review exists to catch.
+
+## Finding format
+
+```
+### [BLOCKER|HIGH|MEDIUM|LOW|INFO] <short title>   (pass: <A|B|C> / <category>)
+- Requirement: <REQ-nn, REQ-nn-ACn — or "none" for unrequested code>
+- Location: <file:line, or a scope when the finding is structural>
+- Evidence: <the snippet or command output that shows it>
+- Why: <what breaks, or which convention it departs from>
+- Recommendation: <what to change — DO NOT apply it>
+```
+
+Severity is judged by consequence, not by how much code it touches.
+
+| Severity | Meaning |
+| :-- | :-- |
+| `BLOCKER` | A requirement is not met, or the change breaks something that worked. Must not merge |
+| `HIGH` | Wrong under a realistic input or state — data loss, a silently swallowed failure, a broken boundary |
+| `MEDIUM` | Wrong under an unusual but reachable state, or a convention departure that will mislead the next reader |
+| `LOW` | A hardening or clarity gap with no reachable failure |
+| `INFO` | Worth knowing; not a defect |
+
+## Output
+
+End the review with, in this order:
+
+1. **Target** — the diff reviewed and the requirement document read.
+2. **Requirement table** — every requirement id → verdict → one line of justification.
+3. **Check table** — every pass B and pass C category → findings count, `PASS` or `N/A`. Pass C
+   always includes its baseline row, so this pass can never be reported as `N/A` in full.
+4. **Findings** — most severe first, in the format above.
+5. **Counts by severity**, and the lint result on one line.
+
+Write the report in the language the reader is using, as the documentation convention requires of
+any document generated for a reader.
+6. **A one-line statement that nothing was modified.**
+
+If any `BLOCKER` or any `PARTIAL` / `MISSING` verdict exists, say plainly that the change does
+not yet satisfy its specification. Do not soften it, and do not bury it under the passing rows.
+
+## Reviewing without a requirement document
+
+- Say so at the top of the report. Pass A is reported as `N/A — no requirement document found`.
+- Do **not** invent the requirements from the code and then review the code against them. That
+  produces a report that always passes.
+- Run passes B and C, and offer to define the requirements first — the specification
+  compliance pass is what makes the review a verification rather than an opinion.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Instead |
+| :-- | :-- | :-- |
+| Fixing what you find while reviewing | The requester loses the decision, and the report no longer describes the code | Report; let the implementer fix |
+| Judging a requirement from a file name or a function name | Names lie; the effect the criterion names may not happen | Read the path from entry point to effect |
+| Reporting formatting the linter already enforces | Buries real findings under noise | One line for the lint result |
+| Listing only problems | The report cannot be used to decide whether to merge | Every requirement and every category gets a verdict |
+| A finding without a location | Cannot be acted on | `file:line`, or a named scope |
+| Grading style preferences as findings | Turns the review into a matter of taste, and gets the real findings ignored | Only convention departures that are actually written down in the project's conventions |
+| Treating "the tests pass" as compliance | Tests can miss the criteria entirely | Check each acceptance criterion against a test or a read code path |
+
+## Detail files
+
+- [specification-compliance.md](./references/specification-compliance.md) — how to judge each
+  requirement, how to detect unrequested code, and how to handle criteria that cannot be judged
+  from source.
+- [correctness-checks.md](./references/correctness-checks.md) — the correctness categories, what
+  to look for in each, and the criteria for raising a finding.
+- [convention-checks.md](./references/convention-checks.md) — the convention categories and how
+  to check the change against the project's own conventions rather than generic ones.

--- a/kit/skills/core/hc-code-review/references/convention-checks.md
+++ b/kit/skills/core/hc-code-review/references/convention-checks.md
@@ -1,0 +1,152 @@
+# Pass C — Convention Conformance
+
+Whether the change is written the way this project writes code.
+
+## The rule that governs this pass
+
+**Check against the project's written conventions, not against generic best practice.**
+
+Before raising any finding in this pass, identify the convention it violates and be able to name
+it. A finding of the form "this would be cleaner as X" is not a convention finding; it is a
+preference, and preferences are excluded by the review rules.
+
+- Load the project's convention set first — the shared coding conventions the project follows
+  (naming, class design and members, module structure, contracts and JSDoc, comments, constants,
+  errors, coding style, documentation), plus anything the project states in its own instruction
+  file.
+- Where the project has no written convention on a point, two things stand in for one: **what
+  the surrounding code already does**, and the **baseline below**. A change that departs from
+  the pattern of the files around it is a finding; a change that follows an unwritten pattern
+  you personally dislike is not.
+- Formatting that the linter enforces is out of scope. Run the lint command, report its result
+  in one line, and do not restate its output as findings.
+
+## C0. The baseline (applies when nothing is written down)
+
+A project with no convention document is not a project with no conventions to check. The
+following are checked on every review, so that this pass can never come back empty for lack of
+a written rule. **A documented project convention overrides any row here**, and a check the
+linter already enforces is skipped.
+
+| Baseline check | It is a finding when |
+| :-- | :-- |
+| Mysterious name | A name does not say what the thing is or does, so the reader must open it to find out |
+| Duplicated code | The same decision or expression is written in more than one place, so a change has to be made twice |
+| Feature envy | A function is more interested in another object's data than its own, and the behavior belongs on that object |
+| Data clump | The same group of values is passed around together everywhere but has no name of its own |
+| Primitive obsession | A domain concept is carried as a bare string or number, so nothing prevents an invalid one |
+| Repeated switch | The same set of cases is branched on in several places, so adding a case means finding them all |
+| Shotgun surgery | One conceptual change forces edits across many files |
+| Divergent change | One module changes for several unrelated reasons |
+| Speculative generality | An abstraction, option or hook exists for a need nobody has stated, with one caller |
+| Message chain | The caller reaches through a chain of objects and so depends on the whole path |
+| Middle man | A class does nothing but delegate, adding a hop without adding meaning |
+| Refused bequest | A subclass inherits members it does not want and does not use |
+
+- Cite the baseline row by name in the finding, and say plainly that it comes from the baseline
+  rather than from a project rule — so the author can answer "we do it that way on purpose",
+  which is a legitimate answer to a baseline finding and not to a documented-convention one.
+- Baseline findings are `MEDIUM` at most, and `LOW` when the code is small and local. They lose
+  to every correctness finding.
+
+## Categories
+
+Each category appears in the report as findings, `PASS` or `N/A`.
+
+### C1. Naming
+
+- Names of classes, methods, properties, accessors, constants and files follow the project's
+  naming convention.
+- A name says what the thing is or does, and is not contradicted by the implementation — a
+  `get*` that writes, a `validate*` that transforms, an `is*` that returns something other than
+  a boolean.
+- Abbreviations, spelling variants and forbidden words follow the project's naming convention
+  rather than the author's habit.
+- New names are consistent with the names already used for the same concept elsewhere in the
+  codebase. Two names for one concept is a finding.
+
+### C2. Class design and members
+
+- The class has state and a reason to exist as a class, per the project's class-design
+  conventions. A class that is only a namespace for functions is a finding where the project
+  prohibits it.
+- Construction, property assignment, immutability and factory-method conventions are followed.
+- Member visibility, accessor rules and the way members refer to each other follow the
+  project's conventions.
+- Responsibilities are not merged: a class that both decides and performs, or that serves two
+  callers for two unrelated reasons, is a finding.
+
+### C3. Module structure
+
+- The file is in the directory the project's structure calls for, and its name matches what it
+  exports.
+- Import grouping and ordering follow the project's convention.
+- The export shape follows the project's convention — in particular where the project requires a
+  class per responsibility rather than a file of loose functions.
+- Nothing new is exported that no other module consumes.
+
+### C4. Contracts, types and JSDoc
+
+- Arguments and return values follow the project's contract conventions, including how arguments
+  are passed (positional versus named) and what a value-producing member returns when it cannot
+  produce a value.
+- Type declarations exist where the project requires them, and describe the actual shape.
+- JSDoc follows the project's convention and is not contradicted by the code — a documented type
+  that the implementation does not honour is a finding, and the wrong one to fix is the JSDoc.
+
+### C5. Comments
+
+- Comments follow the project's language and content conventions.
+- A comment that restates the line above it, or that describes code that no longer exists, is a
+  finding.
+- Commented-out code is a finding.
+- A comment that explains *why* a non-obvious choice was made is the one kind that should be
+  present and is often missing — note its absence where the code makes a choice a reader would
+  question.
+
+### C6. Constants and configuration
+
+- Values that the project's constant convention requires to be declared as constants are not
+  written inline at their use sites.
+- Constants are declared in the place and the file form the project requires.
+- Values that vary by environment are read from configuration rather than hard-coded, and a new
+  configuration value is declared wherever the project declares them.
+
+### C7. Errors
+
+- Error creation, propagation and message form follow the project's error conventions, including
+  the convention for what a member returns when it cannot produce a value.
+- Error identifiers are declared where the project declares them, rather than invented at the
+  throw site.
+- Messages follow the project's documentation convention for referring to class members.
+
+### C8. Coding style beyond the linter
+
+- Expression wrapping, chain breaking and argument layout follow the project's coding-style
+  convention where the linter does not enforce them.
+- Control flow follows the project's convention — nesting depth, the policy on ternaries, and
+  the preference between statement sequences and higher-order forms.
+- Blank-line and grouping conventions are followed where the project treats them as structural
+  rather than cosmetic.
+
+### C9. Documentation
+
+- Documentation the project requires alongside a change exists and is updated: the README
+  sections the project's convention names, the API reference for a changed public member, and
+  the feature's own documents.
+- The requirement definition document and the progress document for the feature reflect what was
+  actually built. A change that silently diverges from its own specification documents is a
+  finding in this category as well as in pass A.
+- Notation for referring to class members follows the project's documentation convention.
+
+## Severity in this pass
+
+| Severity | When |
+| :-- | :-- |
+| `HIGH` | The departure will produce a defect — a JSDoc contract the code violates, an error identifier a caller cannot match on |
+| `MEDIUM` | The departure will mislead the next reader, or splits one concept across two conventions |
+| `LOW` | A local departure with no consequence beyond consistency |
+| `INFO` | The project has no convention on the point; noted so it can be decided |
+
+Never raise a convention finding above `MEDIUM` on consistency grounds alone. Convention
+findings that outrank correctness findings in the report make the report unusable.

--- a/kit/skills/core/hc-code-review/references/correctness-checks.md
+++ b/kit/skills/core/hc-code-review/references/correctness-checks.md
@@ -1,0 +1,86 @@
+# Pass B — Correctness
+
+Where the code is likely to be wrong, independently of whether it matches the specification.
+
+Each category below states what to look for and when it becomes a finding. Every category
+appears in the report as findings, `PASS` or `N/A`.
+
+## 1. Input handling
+
+| Look for | Finding when |
+| :-- | :-- |
+| Values that reach a store, a query or an external call without being validated | An input crosses a boundary unchecked and a malformed value would be persisted or forwarded |
+| Validation that admits values the code below cannot handle | The validator's accepted range is wider than what the implementation handles |
+| Optional values treated as always present | An absent value would produce an unclear failure rather than the specified one |
+| Numeric and boundary values (zero, negative, maximum, empty collection) | A boundary value takes a path that was clearly not intended |
+
+## 2. Error and failure paths
+
+| Look for | Finding when |
+| :-- | :-- |
+| A failure caught and discarded | A `catch` produces no error, no log and no state change — the caller cannot tell it failed |
+| A failure turned into a success-shaped value | An error path returns the same shape as success, so the caller proceeds on bad data |
+| The wrong error surfaced | The error returned differs from the one the specification names, or leaks internal detail outward |
+| A failure path that was never given a value to return | A branch falls through and returns `undefined` implicitly |
+| An `await` missing on a call that can reject | A rejection becomes unhandled and the failure surfaces somewhere unrelated |
+
+## 3. Boundaries: transactions and side effects
+
+| Look for | Finding when |
+| :-- | :-- |
+| Several writes that must succeed or fail together | They are not inside one transaction, and a partial failure leaves the store inconsistent |
+| An irreversible side effect inside a transaction that can roll back | A mail, a payment, an external call or a queue push happens and the transaction then rolls back |
+| A side effect that must survive the response | It is fired without being handed to the mechanism that guarantees it runs |
+| A read used to decide a write | The read is outside the transaction that performs the write, so the decision can be stale |
+
+## 4. Concurrency and repetition
+
+| Look for | Finding when |
+| :-- | :-- |
+| Check-then-write on a value another request can change | Two concurrent requests would both pass the check |
+| An operation that can be delivered twice (a retry, a re-submitted form, a redelivered job) | The second delivery produces a second effect where it should produce none |
+| A counter, a balance or a status updated by reading and then writing | The update is not atomic and concurrent updates would be lost |
+| Uniqueness enforced only in application code | The store permits the duplicate, so a race writes it |
+
+## 5. Data access
+
+| Look for | Finding when |
+| :-- | :-- |
+| A query inside a loop over rows | The row count is not bounded by the data model, so the query count grows with the data |
+| An unbounded read (no limit, no pagination) | The result set grows with the data and nothing caps it |
+| A filter applied after fetching | Rows are fetched and discarded in memory that the store could have excluded |
+| A write of a value that another column already derives | The two can disagree, and nothing keeps them in step |
+| A query built from a value that came from outside | The value is interpolated rather than bound as a parameter |
+
+## 6. Resources and lifecycle
+
+| Look for | Finding when |
+| :-- | :-- |
+| An acquired connection, handle, timer, subscription or lock | There is a path — especially a failure path — on which it is not released |
+| An unbounded accumulation (a cache, a map, a list keyed by request) | Nothing removes entries, so it grows for the lifetime of the process |
+| A long operation with no ceiling | An external call or a query has no timeout and can hold a resource indefinitely |
+
+## 7. Test coverage of the acceptance criteria
+
+This category is about whether the change's tests can detect a regression against the
+specification. It is not a review of test style.
+
+| Look for | Finding when |
+| :-- | :-- |
+| A criterion with no test | An acceptance criterion is satisfied by code but nothing would notice if it broke — `MEDIUM`, or `HIGH` for a criterion about a failure or a permission |
+| A test that asserts less than the criterion states | The criterion names a value and the test only asserts that something was returned |
+| A test that would pass against a stub of the thing it tests | The assertion does not depend on the behavior under test |
+| Failure cases tested only for "it throws" | The specification names which failure, and the test does not distinguish it |
+| A test whose expectation contradicts the specification | Report as a `BLOCKER` — either the test or the implementation encodes the wrong behavior, and one of them is shipping |
+
+## 8. Change safety
+
+| Look for | Finding when |
+| :-- | :-- |
+| A changed shared function, constant or type | A caller outside the feature relies on the old behavior and was not updated |
+| A changed response shape, error code or field name | An existing client would break and no compatibility path exists |
+| A schema change | It is not reversible, or existing rows do not satisfy the new constraint |
+| A removed export, route or operation | Something still references it |
+
+Trace at least one caller for every shared thing the change touches. A change reviewed only
+within its own files cannot see the failure it causes elsewhere.

--- a/kit/skills/core/hc-code-review/references/specification-compliance.md
+++ b/kit/skills/core/hc-code-review/references/specification-compliance.md
@@ -1,0 +1,90 @@
+# Pass A — Specification Compliance
+
+Judging the change against the requirement definition document. This pass answers two
+questions: **is everything that was specified there**, and **is anything there that was not
+specified**.
+
+## Procedure
+
+1. List every requirement id in the requirement document, including withdrawn ones.
+2. For each requirement, list its acceptance criteria ids.
+3. For each criterion, find the code path that produces the outcome it names, and read it from
+   the entry point to the effect. Record the path as the evidence for the verdict.
+4. Assign the requirement's verdict from its criteria, using the rules below.
+5. Walk the change once more from the other direction: for each changed file, name the
+   requirement it serves. Anything that serves none becomes an `UNREQUESTED` finding.
+
+## Judging a criterion
+
+A criterion is satisfied when the code path that produces its outcome has been read and does
+produce it — for the state the criterion names, not for the happy path in general.
+
+| Situation | Verdict for the criterion |
+| :-- | :-- |
+| The path exists and produces the stated outcome | Satisfied |
+| The path exists but produces a different outcome (different error, different field, different record) | Not satisfied — this is the most common real finding |
+| The path exists only for the success case; the criterion names a failure case | Not satisfied |
+| The outcome depends on configuration that is not set | Not satisfied; name the missing configuration |
+| The outcome can only be judged by running the system (timing, volume, concurrency at scale) | `UNVERIFIABLE`; state what would be needed |
+
+- **A test that asserts the criterion is evidence, but not a substitute for reading the path.**
+  A test can assert against a stub and pass while the real path is wrong.
+- **A criterion satisfied only under an input the code never receives is not satisfied.** Check
+  that the validation layer in front of the path actually admits the input the criterion names.
+
+## From criteria to the requirement verdict
+
+| Criteria state | Requirement verdict |
+| :-- | :-- |
+| All satisfied | `IMPLEMENTED` |
+| Some satisfied, some not | `PARTIAL` — list the unsatisfied criterion ids |
+| None satisfied and no code addresses it | `MISSING` |
+| The requirement document marks it withdrawn | `WITHDRAWN` |
+| At least one criterion is unverifiable and the rest are satisfied | `UNVERIFIABLE` — say which criterion and what is needed |
+
+Never round `PARTIAL` up to `IMPLEMENTED` because the remaining criterion is small. The size of
+the gap belongs in the severity of the finding, not in the verdict.
+
+## Unrequested code
+
+Code in the change that serves no requirement is reported, with one of these classifications.
+
+| Classification | Example | Severity guidance |
+| :-- | :-- | :-- |
+| Unrequested behavior | An endpoint, field, flag or side effect nobody asked for | `MEDIUM`, or `HIGH` when it is reachable from outside and changes data |
+| Scope creep into unrelated code | A refactor of a module the feature does not touch | `MEDIUM` — it widens the blast radius of the change |
+| Speculative generality | An abstraction, option or hook with exactly one caller and no stated need | `LOW` |
+| Leftovers | Debug output, commented-out code, an unused import or export, a file nothing references | `LOW` |
+
+Two things are **not** unrequested code, and must not be reported as such:
+
+- Anything the requirement document's out-of-scope section names as handled elsewhere.
+- The mechanics an implementation needs to exist at all — the migration behind a stored value,
+  the validator in front of an input, the type declaration for a contract. These serve the
+  requirement even though no criterion names them.
+
+## Requirements the change was not supposed to touch
+
+A change frequently alters behavior that an *earlier* requirement already fixed. Check the
+requirement documents of the feature being changed for requirements marked done that this diff
+could break — a changed shared validator, a changed error code, a changed default.
+
+- A change that breaks a previously satisfied requirement is a `BLOCKER`, regardless of how
+  small the diff is.
+- Name the earlier requirement id in the finding, so it is clear this is a regression against a
+  specification and not a matter of preference.
+
+## Reporting this pass
+
+The requirement table comes first in the report and has one row per id.
+
+```
+| ID | Requirement | Verdict | Justification |
+| :-- | :-- | :-- | :-- |
+| REQ-01 | Sign-in with email and password | IMPLEMENTED | AC1–AC3 each traced from the mutation entry point to the token issue |
+| REQ-02 | Failed attempts are limited | PARTIAL | AC1, AC3 satisfied; AC2 not — the lock never expires, see finding 1 |
+| REQ-03 | Sign-in response time | UNVERIFIABLE | Needs a 100-concurrent-request measurement; no load environment |
+```
+
+Each `PARTIAL`, `MISSING` and `UNREQUESTED` row has a corresponding finding in the findings
+section. A verdict without a finding to explain it is not actionable.

--- a/kit/skills/core/hc-coding-styles/SKILL.md
+++ b/kit/skills/core/hc-coding-styles/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: hc-coding-styles
+description: "Coding style conventions. Covers where to chop down (wrap) expressions, method/property chains, function-call arguments, template literals, regular-expression flags, and more."
+---
+
+# Coding Styles
+
+Conventions related to coding style.
+
+## Chop down immediately before a binary operator
+
+- When a line contains multiple expressions, chop down immediately before the binary operator (place the operator at the start of the next line).
+- Literals are not considered expressions here. Therefore, when one of the operands is a literal (e.g., `length + 1`), do not chop down.
+
+```javascript
+// NG
+const total = alpha + beta + gamma
+
+// OK
+const total = alpha
+  + beta
+  + gamma
+```
+
+### Chop down `??` as a branch
+
+- Strictly speaking, `??` is syntactic sugar for an `if` statement / ternary operator (a branch). Therefore, the literal exception for binary operators does not apply, and it is **always chopped down as a branch** (placing `??` at the start of the next line).
+- In other words, even when the right operand is a literal (such as `null`), `?? null` is not placed on the same line — it is wrapped onto a new line.
+
+```javascript
+// NG: applying the literal exception and keeping it on the same line
+const author = this.entity.comment?.author ?? null
+
+// OK: chop down immediately before `??` as a branch
+const author = this.entity.comment
+  ?.author
+  ?? null
+```
+
+## When an if statement's condition spans multiple lines, apply consistency chopping down to `()`
+
+- When an if statement's condition spans multiple lines, apply consistency chopping down to the condition's `()`.
+  (Break the line immediately after `(`, place each condition on its own line, and place `)` on its own line.)
+
+```javascript
+// NG
+if (!Number.isInteger(length)
+  || length < 0) {
+  // ...
+}
+
+// OK
+if (
+  !Number.isInteger(length)
+  || length < 0
+) {
+  // ...
+}
+```
+
+## Write one method per line in a method chain
+
+- Write one method per line.
+- When writing a method chain, allow at most one receiver per line, and at most one method per line.
+- `this` does not count as a receiver.
+- Unless instructed to chop down, place the first method of a method chain on the same line as the receiver.
+
+```javascript
+// NG
+const ids = this.extractSamples().filter(it => it).map(it => it.id)
+
+// NG (not one method per line)
+const ids = this.extractSamples()
+  .filter(
+    it => it
+  ).map(
+    it => it.id
+  )
+
+// OK
+const ids = this.extractSamples()
+  .filter(it => it)
+  .map(it => it.id)
+```
+
+## Write one property per line in a property chain
+
+- Write one property per line.
+- A receiver is not considered a property. `this.xxxx` is considered a receiver.
+- This criterion also conforms to the "Law of Demeter".
+
+```javascript
+// NG
+const id = this.entity.comment.author.id
+
+// OK
+const username = this.entity.username
+
+const id = this.entity.comment
+  .author
+  .id
+```
+
+## Chop down when the same punctuation mark repeats consecutively
+
+- Apply chop down when the same punctuation mark occurs consecutively.
+- This is a habit to avoid making the reader count the nesting of `()` or `{}`.
+
+```javascript
+// NG
+console.log(Math.round(average(SCRIPTS.filter(it => it.living)
+  .map(it => it.year))))
+
+// OK
+console.log(
+  Math.round(
+    average(
+      SCRIPTS.filter(it => it.living)
+        .map(it => it.year)
+    )
+  )
+)
+```
+
+## For function calls with two or more arguments, write one argument per line
+
+- When calling a function with two or more arguments, limit arguments to one per line (chop down).
+
+```javascript
+// NG: two arguments on the same line
+this.delimiter.replace(specialCharacterPattern, '\\$<special>')
+
+// OK: one argument per line
+this.delimiter.replace(
+  specialCharacterPattern,
+  '\\$<special>'
+)
+```
+
+## Do not make meaningless variable assignments when chop down alone secures readability
+
+- If chop down secures the readability of the expression, do not assign it to a meaningless variable.
+
+```javascript
+// NG: assigning to a meaningless variable when chop down alone would suffice
+const specialCharacterPattern = /(?<special>[.*+?^${}()|[\]\\])/ug
+
+return this.delimiter.replace(
+  specialCharacterPattern,
+  '\\$<special>'
+)
+
+// OK: secure readability with chop down, without a variable assignment
+return this.delimiter.replace(
+  /(?<special>[.*+?^${}()|[\]\\])/ug,
+  '\\$<special>'
+)
+```
+
+## Do not write two or more complex expressions on one line
+
+- Do not write two or more complex expressions on a single line.
+- When there are multiple complex expressions, split them by naming them with `const`, etc., so that there is at most one complex expression per line.
+
+```javascript
+// NG: two complex expressions on one line (two method calls)
+return `${segment.charAt(0).toUpperCase()}${segment.slice(1).toLowerCase()}`
+
+// OK: split each into its own const
+const head = segment.charAt(0)
+  .toUpperCase()
+const tail = segment.slice(1)
+  .toLowerCase()
+
+return `${head}${tail}`
+```
+
+## Do not create unnecessary intermediate strings
+
+- In "string → string" conversions, do not create unnecessary intermediate strings.
+- By making full use of regular expressions, most conversions can be done in a single pass (a single `replace` / `replaceAll`).
+
+```javascript
+// NG: creating an intermediate string with toLowerCase() and then calling replaceAll (2 passes)
+return text.toLowerCase()
+  .replaceAll(pattern, replacer)
+
+// OK: convert with a single replaceAll
+return text.replaceAll(pattern, replacer)
+```
+
+## Use template literals for string concatenation
+
+- For string concatenation, do not use `alpha + beta`; use the template literal `` `${alpha}${beta}` ``.
+
+```javascript
+// NG
+return head
+  + tail
+
+// OK
+return `${head}${tail}`
+```
+
+## Regular expression literal flags
+
+- Always attach the `u` flag to regular expressions written as literals (mandatory). Place it immediately after the closing `/`.
+- Other flags such as `i` or `g` are placed after `u` in alphabetical order.
+
+```javascript
+// NG: missing the u flag
+const pattern = /[A-Z]/g
+
+// OK: u first, the rest in alphabetical order (g → i)
+const pattern = /[A-Z]/ug
+const another = /[a-z]/ugi
+```

--- a/kit/skills/core/hc-comments/SKILL.md
+++ b/kit/skills/core/hc-comments/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: hc-comments
+description: "Comment-writing conventions. Comments within actual code should be written in English unless there is a reason otherwise."
+---
+
+# Shared: Comments
+
+Conventions related to comment writing. Applies across both JSDoc and inline comments (`//`).
+
+## Language
+
+- Comments in actual code are written in English unless there is a reason otherwise. **Generated code** (such as test code) is also included as actual code.
+- Only when there is a specific reason (such as needing to explain Japanese-specific background), it is acceptable to
+  write in Japanese.
+- **Exception**: Comments within **code examples intended for explanation** in documentation/skills (Markdown ` ``` ` code blocks) are not actual code, so they are exempt from this convention (English) and should be written in the same language as the surrounding explanatory text.

--- a/kit/skills/core/hc-constants/SKILL.md
+++ b/kit/skills/core/hc-constants/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: hc-constants
+description: "Conventions for constants. Covers naming (uppercase SNAKE_CASE / singular for enum-like objects), chopping down, and the file organization and placement of object-type constants."
+---
+
+# Constants
+
+Conventions related to defining constants.
+
+## Naming
+
+- Constant names must be written in all-uppercase SNAKE_CASE.
+
+```javascript
+// NG
+const maxRetryCount = 3
+
+// OK
+const MAX_RETRY_COUNT = 3
+```
+
+## Naming of enum-like objects
+
+- When defining constants as an enum-like object, use the singular form for the name.
+- Following the naming convention of enums, do not use the plural form.
+
+```javascript
+// NG: plural
+const COLORS = {
+  RED: 'red',
+  GREEN: 'green',
+  BLUE: 'blue',
+}
+
+// OK: singular
+const COLOR = {
+  RED: 'red',
+  GREEN: 'green',
+  BLUE: 'blue',
+}
+```
+
+## Chopping down
+
+- In object-type constant definitions, chop down per property (one property per line).
+
+```javascript
+// NG: multiple properties on one line
+const COLOR = { RED: 'red', GREEN: 'green', BLUE: 'blue' }
+
+// OK: one property per line
+const COLOR = {
+  RED: 'red',
+  GREEN: 'green',
+  BLUE: 'blue',
+}
+```
+
+## File organization for object-type constants
+
+- When defining an object-type constant, keep one definition per file.
+- The file name must match the definition name.
+
+```
+// OK: COLOR is defined alone in COLOR.js
+COLOR.js
+  → const COLOR = { ... }
+```
+
+## Location
+
+- Unless otherwise specified, define constant files under `<project-root>/constants/`.
+- Subfolders may be used as appropriate, depending on the kind of constant.
+
+```
+<project-root>/constants/COLOR.js
+<project-root>/constants/http/STATUS_CODE.js
+```

--- a/kit/skills/core/hc-contracts/SKILL.md
+++ b/kit/skills/core/hc-contracts/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: hc-contracts
+description: "Conventions for the type contracts of function and method arguments and return values, including how contract types are defined."
+---
+
+# Shared: Contracts
+
+Conventions related to argument and return-value contracts. Applies across both functions and methods.
+
+## Use BooleanLike for boolean return values
+
+- When returning a boolean, use the `BooleanLike` type.
+- To do so, define the `BooleanLike` `@typedef` at the bottom of the file.
+- If the type is already defined as standard, `@typedef` is unnecessary.
+- Follow the JSDoc convention ("Writing `@typedef`") for the `@typedef` format.
+
+```javascript
+/**
+ * Check whether the value is valid.
+ *
+ * @param {{
+ *   value: *
+ * }} params - Parameters.
+ * @returns {BooleanLike} Whether the value is valid.
+ */
+function isValid ({
+  value,
+}) {
+  return value != null
+}
+
+// Defined at the bottom of the file
+/**
+ * @typedef {*} BooleanLike
+ */
+```

--- a/kit/skills/core/hc-dependency-defect/SKILL.md
+++ b/kit/skills/core/hc-dependency-defect/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: hc-dependency-defect
+description: "How to deal with a bug in code this project uses but does not own — a framework, an in-house package, anything inside `node_modules/`. Covers where to put the workaround, what to name it, and how to mark it so it can be deleted later. Use when a package behaves wrongly and the correction has to live in this project. A bug in code this project owns is fixed directly instead."
+---
+
+# Dependency Defect
+
+**Never edit code this project uses but does not own. Work around it instead.**
+
+Code this project does not own means a framework, an in-house package, or anything inside
+`node_modules/`. This skill explains how to write that workaround and where to put it. **It does not
+decide who approves the work, which branch it goes on, or what gets written down outside the code.**
+The team's process decides those.
+
+**A bug in code this project owns is a different thing.** Fix that code directly.
+
+## The steps
+
+0. **Check whether the package already fixed it.** Read the package's own history: the version in
+   use, and every version after it. If the fix is already there, upgrade the package and stop.
+1. **Add a class in this project that extends the broken class.**
+2. **Override only the member that is broken.**
+3. **Use the new class at every call site.**
+4. **Write a comment saying why the class exists**, so someone can delete it later.
+
+**Step 0 is the one people skip.** Then they write a subclass that repeats a fix the package already
+shipped. Reading the history takes a few minutes.
+
+## Why a subclass, and not something else
+
+| What people do instead | What goes wrong |
+| :-- | :-- |
+| Edit the package inside `node_modules/` | The next install wipes the edit. Nothing shows that it was ever there, so the bug comes back and nobody knows why. |
+| Fork the package | Every future upgrade turns into a merge. Forever, for one bug. |
+| Rewrite what the package does | As much work as a fork, and now this project owns all of it. Fixes to the parts that were never broken stop arriving. |
+| Replace the class's methods at runtime | The call site looks normal, so a reader cannot tell that the behavior changed, and has no file to open. If two of these run in one process, whichever one loads last wins. |
+| Copy the class into this project and fix the copy | The same problems as a fork, in one file. |
+
+**A small bug is not an excuse to pick one of these.** The rule holds because the code belongs to
+someone else, and they will change it again.
+
+## Step 1 — add a subclass of the broken class
+
+The subclass is normal code in this project. It follows the same rules as every other class here.
+
+- **Put it where this project keeps its other classes of that kind.** Never create a folder named
+  after the package, and never put the file next to the package's own files.
+- **Name it after what it does**, as a singular UpperCamelCase noun, like any other class here. Do
+  not use names like `PatchedXxxx`, `FixedXxxx` or `XxxxWorkaround`. Those names describe how the
+  file was born, not what it does, and they become wrong if the class is kept for another reason.
+  The reason belongs in the comment of step 4.
+- **Import the broken class the way the package exports it** (default or named). Put that import with
+  the other package imports at the top of the file, as the import convention says.
+- **This subclass does not need a property of its own.** A class here normally has to hold state, but
+  that rule does not apply once a class has `extends`. The parent holds the state, and the parent
+  already decides the constructor arguments.
+
+## Step 2 — override one member, not the whole class
+
+**Override one member, and the subclass keeps getting every later improvement from the package.**
+Rewrite the whole class, and it stops getting them the moment you write it. Nothing warns you.
+
+- Override the one method that behaves wrongly, and call `super` for everything else.
+- Override a getter when the parent computes a value wrongly.
+- Do not copy the parent's code into the child and change two lines.
+- Do not override a member that already works, just to keep the class tidy.
+- Put `/** @override */` above every override.
+
+**When the correct answer needs part of the parent's work, call the parent and correct its result.**
+Do not rewrite what it does.
+
+```javascript
+// NG: the parent's code is copied here, so the package's later fixes never reach this class
+export default class SingleDayDateRangeFormatter extends DateRangeFormatter {
+  /** @override */
+  formatRange ({
+    startedOn,
+    endedOn,
+  }) {
+    if (startedOn === endedOn) {
+      return startedOn
+    }
+
+    return `${startedOn} - ${endedOn}` // copied out of the package, minus the bug
+  }
+}
+
+// OK: only the broken case is handled here, and the rest stays with the parent
+export default class SingleDayDateRangeFormatter extends DateRangeFormatter {
+  /** @override */
+  formatRange ({
+    startedOn,
+    endedOn,
+  }) {
+    if (startedOn === endedOn) {
+      return startedOn
+    }
+
+    return super.formatRange({
+      startedOn,
+      endedOn,
+    })
+  }
+}
+```
+
+**A class whose name starts with `Base` is meant to be extended.** Extending it is normal use of the
+library, not a workaround. Nothing in this skill applies to it: no comment, and no deletion
+condition.
+
+## Step 3 — call the new class by its own name
+
+**Every call site names the new class.** A reader who follows the import then lands on the class that
+really runs.
+
+- Import this project's class by its own name at each call site.
+- Do not re-export the subclass under the original's name.
+- Do not rename the import so that the original's name points at the subclass.
+- Do not overwrite the original's prototype or its export.
+
+```javascript
+// NG: exported under the package's name, so the import lies about what it loads
+export {
+  default as DateRangeFormatter,
+} from './SingleDayDateRangeFormatter.js'
+
+// NG: renamed at the call site, with the same result
+import {
+  default as DateRangeFormatter,
+} from '../modules/SingleDayDateRangeFormatter.js'
+
+// OK: the call site imports this project's class by its own name
+import SingleDayDateRangeFormatter from '../modules/SingleDayDateRangeFormatter.js'
+```
+
+Hide the swap, and the next person opens the package's source looking for behavior that is not there
+any more.
+
+**Many call sites is not a reason to hide the swap.** It is a reason to report how big the change is,
+because files outside the current task are not this task's to change.
+
+## Step 4 — write the reason above the class
+
+**Without a comment, the workaround stays forever.** Nobody deletes a class when nobody knows why it
+is there.
+
+Write the reason right above the class, in English, like any other comment. Name members in the
+`#instanceMember` / `.staticMember` style of the documentation convention. Say what has to happen
+before someone can delete the file:
+
+```javascript
+/*
+ * Works around <package>@<version>: <class>#<member> <what it does wrong>.
+ * Remove this class and go back to <original> once <the condition> holds.
+ * Reported upstream: <link>, or "not reported yet".
+ */
+```
+
+**"Remove this once the package fixes it" is not a condition**, because nobody can check it. A
+version number or an issue link can be checked. If nobody has told the package authors yet, write
+"not reported yet". That is honest, and it tells the next reader what is still missing.
+
+## When the broken thing is a function, not a class
+
+**Wrap it.** Add a class in this project that calls the function and corrects its result, and have
+the call sites use that class. The same rules apply: correct the result, do not rewrite the function.
+It is a class rather than another function, because this project writes one class per job (see
+`hc-modules-exports`).
+
+## When a subclass cannot reach the broken part
+
+Some parts cannot be overridden: private members, values kept inside the module, or behavior decided
+before the class is created. **Stop and report it.** Do not fall back to a row from the table above
+just because the subclass did not work.
+
+Report the package and its version, the class or function, what it does now, what it should do, and
+what exactly blocks the subclass.
+
+## Rules
+
+- Never edit, fork, copy, rewrite, or patch the package while it runs
+- Read the package's history first: the version in use, and every version after it
+- Correct the bug with a class in this project that extends the broken class, overrides only the
+  broken member, and calls the parent for the rest
+- Correct a broken function with a class in this project that wraps it
+- Call this project's class by its own name, and never let the original's name point at it
+- Report a broken part that a subclass cannot reach, instead of working around it some other way
+- Give every workaround a comment stating the package, the version, the bug, and what has to happen
+  before the file can be deleted

--- a/kit/skills/core/hc-deployment-document/SKILL.md
+++ b/kit/skills/core/hc-deployment-document/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: hc-deployment-document
+description: >
+  Write a server deployment runbook through conversation with whoever will run it — the hosting
+  and process-management profile, the first-time build, the repeatable release, migrations,
+  rollback and the post-release checks. Every step carries the output that confirms it worked.
+  Use when the user asks for deployment steps, a release procedure or a server setup document.
+  Executing the deployment and building the CI/CD pipeline are out of scope.
+---
+
+# Deployment Document
+
+A skill for writing a **server deployment runbook**, through conversation with the person who will
+run it.
+
+The output is not a description of the finished server. It is a document someone follows **line by
+line, on a system that is already serving real traffic**. Each line says what to run, what the
+right output looks like, and what to do when the output is something else.
+
+## Core principle: the document protects every moment in between, not the end state
+
+A deployment is not a jump from one good state to another. It is a sequence of steps, and a running
+system passes through **every state in between**. After any step, the code that is live right now
+and the data that exists right now must still work.
+
+Everything else in this skill comes from that:
+
+- Write a schema change so that the **code already deployed** still works afterwards.
+- When you rotate a secret, accept **both** the old and the new one for a while.
+- Mark every step you cannot undo, and put a backup step right before it.
+- A release with no way back is not finished.
+
+**A runbook that only works when every step succeeds is not a runbook.** It describes the happy
+path, and nobody opens the document when things are going well.
+
+## The skill is not finished until the operator approves
+
+The document has two states, recorded in its header.
+
+| State | Meaning |
+| :-- | :-- |
+| `DRAFT` | Written, but not yet confirmed by the person who will run it. Do not deploy from it. |
+| `APPROVED` | They have read it and confirmed it. It may be followed. |
+
+- Never mark a document `APPROVED` for them.
+- A document with an open question cannot be `APPROVED`. Either answer the question, or drop the
+  step and record it as out of scope.
+
+## Procedure
+
+Work through the five phases in order. Do not skip to drafting.
+
+| # | Phase | What happens |
+| :-- | :-- | :-- |
+| 1 | Settle the profile | Ask what the target actually is — hosting, OS, edge, process manager, database, secrets, TLS. See [interview.md](./references/interview.md). |
+| 2 | Read what exists | If the system is already running, read its current unit files, edge configuration, applied migrations and deployed tag before asking about them. |
+| 3 | Design for compatibility | Decide, per step, whether it is reversible, whether it interrupts service, and whether it can coexist with the code already deployed. See [compatibility.md](./references/compatibility.md). |
+| 4 | Draft | Produce the document from the template. See [document-template.md](./references/document-template.md). |
+| 5 | Approve | Present it, ask for confirmation, then set the state to `APPROVED`. |
+
+- **Phase 2 keeps phase 1 short.** If you can read it off the server or out of the repository, do
+  not ask. Asking spends the operator's attention on something you could have looked up.
+- Phases 1 and 3 repeat. Two or three rounds is normal.
+
+## Rules for the conversation
+
+- **Group questions by topic and ask about five at a time.** A list of twenty gets one answer.
+- **Give every question a suggested answer**, so the operator can agree instead of writing. This
+  skill assumes Ubuntu LTS, nginx, systemd, git on the server, a `.env` file and Let's Encrypt —
+  see [interview.md](./references/interview.md).
+- **Always ask two questions**, because no default is safe for either. Is this a first build, or a
+  release onto a system already running? And how much downtime is allowed?
+- If you ask something and get no answer, put it in the document as an **open question**. Never
+  write a guess as though it were decided.
+
+## Every step states how it is verified
+
+If you cannot confirm a step worked, it is not a step. Every step carries all seven of these:
+
+| Field | Why it is not optional |
+| :-- | :-- |
+| Purpose | One line. If nobody can say why a step is there, nobody can safely skip it or move it. |
+| Preconditions | What must already be true. This is what lets someone check the order is right. |
+| Command | Exactly what to run. Chapter 0 lists what every placeholder means. |
+| **Expected output** | What the screen shows when it worked. Without it, people read "it ran" as "it worked". |
+| On failure | What to do. Not "investigate" — which log to open, and which step to go back to. |
+| Rollback | How to undo it. If it cannot be undone, say so in those words. |
+| Interrupts service? | Yes or no. The operator needs to know before running it, not after. |
+
+## The document is in two parts
+
+Building the server the first time and releasing to it are different jobs. People read them at
+different times, in a different frame of mind. Put them in one sequence and the person doing their
+fortieth release has to scroll past thirty steps that ran once, a year ago.
+
+| Part | Read | Holds |
+| :-- | :-- | :-- |
+| I — first-time build | Once | The instance, the OS baseline, networking, git access, environment variables, TLS and keys, the edge, the process manager |
+| II — every release | Every time | Fetch, install, build, migrate, restart, reload, verify, roll back, and the checks that were deferred to production |
+
+Chapter 0 belongs to neither part, and everyone reads it. It holds the agreed profile, the
+placeholder list, the permissions needed and how long it all takes. It also says **what the
+operator's own machine needs**: an SSH client, a key with the right permissions, and the right line
+endings on any file they upload.
+
+## The edge configuration chapter is an original, not a copy
+
+The local E2E environment copies its proxy configuration from the chapter that sets up the reverse
+proxy. `hb-build-e2e-test-environment` requires that copy, and requires the copy to record where it
+came from.
+
+- Write the chapter so it is easy to copy: one file, with the parts that change per environment
+  (TLS termination, upstream address, host name) easy to spot.
+- Say in the chapter that it is the original. If nobody knows a file is copied elsewhere, they edit
+  it as though it were theirs alone.
+
+## Where the document lives
+
+```
+docs/deployment/
+└── <environment>.md      the runbook for one environment — production.md, staging.md
+```
+
+- One environment, one document. Even if two environments differ in only three values, write two
+  documents. A runbook full of "unless it is staging, in which case…" gets read wrong under
+  pressure.
+- If the project already has a place for operational documents, use it, and keep the file name
+  `<environment>.md`.
+- Write it in the language the person running it speaks, as the documentation convention asks for
+  any document written for a reader.
+
+## Scope
+
+| In scope | Out of scope |
+| :-- | :-- |
+| Writing the runbook | Executing the deployment |
+| The server-side steps, whoever runs them | Implementing the CI/CD pipeline |
+| One section on what changes when CI runs the steps instead of a person — key handling, the executing user, and what replaces an interactive confirmation | Pipeline configuration, runner setup, workflow files |
+
+Deployment is where a wrong guess costs the most, so the line matters. This skill writes the
+document. Someone allowed to break production runs it.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Instead |
+| :-- | :-- | :-- |
+| A step with a command but no expected output | People read "no error message" as success, even when the command did nothing at all | Say what the screen shows when it worked |
+| Dropping a column in the same release that stops using it | The old code is still running while the migration runs, and it asks for a column that is gone | Add first, deploy, then remove in a later release |
+| "Restart nginx" in the edge chapter | A restart drops every request in progress, including the operator's own check | Run `nginx -t`, then reload |
+| One document for both production and staging | People read the differences as optional, and apply the wrong one under pressure | One document per environment |
+| Rollback written as "revert the commit and redeploy" | It says nothing about the data, and the data is the part you cannot revert | Say how far back you can go, where the limit is, and put the backup before it |
+| Rotating a secret by replacing the value | Every token issued so far stops working at once, so the rotation causes an outage | Accept old and new together, then drop the old |
+| A first-build step left in the release part | It runs again on a live system, a year after anyone remembers what it does | Part I once, part II every time |
+
+## Detail files
+
+- [interview.md](./references/interview.md) — what to ask, the default profile behind each
+  question, and what a different answer changes in the document.
+- [document-template.md](./references/document-template.md) — the two-part chapter structure, the
+  header, and the shape of one step.
+- [compatibility.md](./references/compatibility.md) — the rules that keep a running system working
+  at every intermediate moment: schema, seeds, environment variables, secrets, API and deploy order.
+- [ubuntu-nginx-profile.md](./references/ubuntu-nginx-profile.md) — the default profile in full:
+  the OS baseline, `ufw`, the systemd unit, the nginx server block, certbot and log rotation.
+- [cloud-and-network.md](./references/cloud-and-network.md) — security groups, IAM, managed
+  databases and load-balancer TLS termination per provider, and what replaces them on a VPS or
+  on-premises.

--- a/kit/skills/core/hc-deployment-document/references/cloud-and-network.md
+++ b/kit/skills/core/hc-deployment-document/references/cloud-and-network.md
@@ -1,0 +1,75 @@
+# Cloud and network
+
+What the network chapter contains per provider, and what replaces it when there is no provider.
+Referenced from the profile in [SKILL.md](../SKILL.md).
+
+## The rules that hold everywhere
+
+Whatever your provider calls its parts, the network chapter answers the same four questions.
+
+| Question | The answer that is always wrong |
+| :-- | :-- |
+| What can reach port 22? | `0.0.0.0/0`. Always a bastion or a fixed address instead |
+| What can reach the application? | Its own port directly. Only 80 and 443 are public, and the application listens on loopback behind the edge |
+| What can reach the database? | Anything outside the private network. **Never make the database port public**, on any provider, in any environment |
+| What can the server reach outbound? | Everything, without anyone deciding so. It needs package mirrors, the git host and the certificate authority. Everything else is a choice |
+
+**Anyone who can reach the database has the data.** No amount of application-level security makes
+up for an open database port. That is why this rule holds whatever your provider calls things.
+
+## Per provider
+
+The names differ. The chapter is the same length either way.
+
+| Concern | AWS | GCP | Azure | OCI / Sakura |
+| :-- | :-- | :-- | :-- | :-- |
+| Ingress rules | Security Group | Firewall rule (by tag) | Network Security Group | Security List / packet filter |
+| Subnet-level rules | Network ACL | — (firewall only) | NSG on the subnet | Security List |
+| Instance identity | IAM instance profile | Service account | Managed identity | Instance principal |
+| Managed database | RDS | Cloud SQL | Azure Database | managed offering or self-hosted |
+| Certificate | ACM (with ALB) | Google-managed | App Service / Front Door | provider's own, or certbot |
+| Where TLS ends | ALB, usually | Load balancer | Application Gateway | often on the instance |
+
+## When TLS ends at a load balancer
+
+This is where runbooks most often go subtly wrong, because the server itself never sees HTTPS.
+
+- **nginx listens on 80**, and the redirect to HTTPS moves to the load balancer. Leave the redirect
+  on the server and you get a loop.
+- **`X-Forwarded-Proto` now matters a lot.** It is the only way the application knows whether the
+  request was HTTPS, so generated links and cookie `Secure` flags depend on a header instead of on
+  the connection.
+- **Only trust that header from the load balancer.** If you accept it from anywhere, the client can
+  set it.
+- **The health-check path must work without a login**, and must not touch the database. A health
+  check that runs a query turns one slow query into a server dropped from the pool.
+
+## Managed databases
+
+- **Check the subnet, not just the security group.** If the application cannot route to the
+  database's subnet, the connection times out instead of being refused, and that looks like the
+  application hanging.
+- **The provider owns the backups, and the schedule.** Chapter 9 says whether the pre-migration
+  backup relies on the automatic one or takes its own. If it relies on the automatic one, say
+  whether the release window overlaps it.
+- **Changing a parameter can restart the database.** A parameter group edit applied "immediately"
+  sometimes does. Write whether it does into the step, rather than leaving it to memory.
+- **The maintenance window limits when you can deploy.** A release scheduled inside it competes
+  with the provider's own restart.
+
+## VPS only, or on-premises
+
+There is no security-group layer, so the host firewall is the only barrier. Chapter 1 therefore
+carries weight that chapter 2 would share on a cloud.
+
+| What the cloud provided | What replaces it |
+| :-- | :-- |
+| Security groups | `ufw`, now the **only** thing between the network and the database port |
+| Instance identity for credentials | A file on disk, with the permissions and rotation that means |
+| Managed backups | A scheduled dump, **plus a restore you have actually tried**. An untested backup is not a backup |
+| Load-balancer TLS | certbot on the server, and the renewal timer is now yours to check |
+| Automatic instance replacement | Nothing. Recovery is manual, and belongs in chapter 11 |
+
+**Hybrid is not a third case. It is both cases, one component at a time.** Write down which
+component sits where. A reader who assumes everything is in one place applies the wrong half of the
+chapter.

--- a/kit/skills/core/hc-deployment-document/references/compatibility.md
+++ b/kit/skills/core/hc-deployment-document/references/compatibility.md
@@ -1,0 +1,96 @@
+# Compatibility with the system that is already running
+
+The rules that keep a live system working at **every moment during** a release, not just at the end.
+Referenced from the compatibility phase in [SKILL.md](../SKILL.md).
+
+They all deal with one situation: **during every release there is a period when the old code and the
+new schema are live together.** How long that period lasts varies. That it happens does not.
+
+## Schema
+
+| Change | Rule |
+| :-- | :-- |
+| Any change to the structure | Add, move, remove — over **three releases**. First add the new shape, then move the data, then remove the old shape. Only remove it once nothing running still reads it |
+| Adding a column | Make it nullable, or give it a default, so the `INSERT` in the running code still works. You cannot add `NOT NULL` with no default to a live table |
+| Renaming | Four releases: add the new name, write to both, move the readers over, drop the old one. Never all at once |
+| Dropping a column | Not in the same release that stops using it. The old code is still running while the migration runs |
+| Adding an index to a big table | Say how long it locks, or use the concurrent form if your database has one. A release that looks stuck is usually this |
+
+**Test every migration like this:** if the deployment stopped right after this step, and the old
+code kept serving requests, would it still work? If not, add a step in front that only adds.
+
+## Seeds
+
+- **Seeds add rows. They never change them.** A seed that rewrites an existing row is really a data
+  migration with the wrong name, and it will run again on the next environment.
+- **Use a reserved range of ids**, so you can tell a seeded row by its id, and it cannot clash with
+  real data.
+- To change an existing row, write a migration. Then it is recorded, ordered, and can be undone.
+
+## Environment variables
+
+The ordering is the whole rule, and it is asymmetric:
+
+| Operation | When |
+| :-- | :-- |
+| Adding a key | **Before** the new code starts. It reads the key on boot |
+| Removing a key | **After** the old code has stopped. It is still reading it until then |
+
+A missing key usually does not crash anything. It arrives as `null`, the application starts, and it
+fails later somewhere that says nothing about configuration. Chapter 4 lists the required keys so
+you catch this by reading, not by an outage.
+
+## Secrets
+
+**Rotation is a three-step sequence, never a substitution.**
+
+1. Start accepting the new secret **as well as** the old one, wherever they are checked.
+2. Start handing out the new one.
+3. Drop the old one, once every token made with it has expired.
+
+Replace the value in one step and every token issued so far stops working at that instant. With a
+signing key, that signs out every user at once — an outage caused by a maintenance job. Say in the
+document how long the overlap lasts and what decides it, which is usually the longest token
+lifetime.
+
+## API and deploy order
+
+- **Never release a breaking API change on its own.** Add the new version, move the callers over,
+  then remove the old one.
+- **Say which side deploys first**, and why. Usually the backend: a frontend asking for a field that
+  does not exist yet breaks, while a backend serving a field nobody asks for yet does no harm.
+- If both go out in the same release, say how long they disagree and what the user sees during
+  that time.
+
+## The edge
+
+- **Run `nginx -t` before every reload.** A syntax error found by the reload is an outage. Found by
+  the test, it is a typo.
+- **Reload. Do not restart.** A reload brings in new workers and lets the old ones finish their
+  requests. A restart drops every request in progress, including the operator's own check.
+- Restarting never fixes a config that fails the test. Put the old file back — which is why you copy
+  it before editing.
+
+## Irreversible steps
+
+- **List them all in one place**, so the operator knows before starting how many points of no
+  return there are.
+- **Put a backup step right before each one.** Check the backup exists and is not empty before
+  going on.
+- Write the rollback around these limits: "you can go back to step 8.4; past that, restore the
+  backup from 9.1 and replay". "Revert the commit" talks about the code and says nothing about the
+  data, and the data is the part that does not revert.
+
+## Downtime
+
+What the operator answered in the interview decides which of these the document is allowed to use:
+
+| Answer | What the release may do |
+| :-- | :-- |
+| None | Expand/contract only; every step reversible; the edge reloads, never restarts |
+| A few minutes off-hours | A stop-migrate-start release is permitted, with the window stated and a maintenance page if there is one |
+| A maintenance page is acceptable | The simple sequence is available, and the document still states the duration and the rollback |
+
+Spreading a migration over three releases when you could have taken a maintenance window wastes two
+of them. Taking the whole system down when you could not is an unplanned outage. That is why you ask
+before you start writing.

--- a/kit/skills/core/hc-deployment-document/references/document-template.md
+++ b/kit/skills/core/hc-deployment-document/references/document-template.md
@@ -1,0 +1,112 @@
+# The document template
+
+The chapter structure, the header, and the shape of a single step. Referenced from the drafting
+phase in [SKILL.md](../SKILL.md).
+
+## Header
+
+```markdown
+# Deployment — production
+
+| | |
+| :-- | :-- |
+| State | DRAFT |
+| Environment | production |
+| Applies to | the release procedure from v1.4.0 onward |
+| Last updated | 2026-08-23 |
+| Approved by | — |
+```
+
+`State` stays `DRAFT` until the person who will run it confirms it. One unanswered question
+anywhere in the document keeps it `DRAFT`.
+
+## Chapter 0 — target and assumptions
+
+Read by everyone, part of neither part.
+
+- **The agreed profile**, as a table: hosting, OS, edge, process manager, database, secret store,
+  TLS. One row per answer from the interview.
+- **The placeholder list.** Every `<host>`, `<domain>`, `<deploy-user>` and `<app-dir>` used below,
+  with its real value — or the words "ask the infrastructure owner".
+- **The permissions needed**, and who grants them.
+- **How long it takes**, and which steps take most of that.
+- **What the operator's own machine needs.** An SSH client. A private key at `600` — **Windows
+  cannot set that**, so fix the key's ACL there instead. And LF line endings on anything you upload:
+  a shell script or unit file with CRLF fails in ways that never mention line endings.
+
+## Part I — first-time build
+
+Read once. Every chapter here is skipped on a system that already exists.
+
+| # | Chapter | Holds |
+| :-- | :-- | :-- |
+| 1 | Infrastructure | The instance, OS baseline, the deploy user and its sudo rights, SSH keys, `ufw`, swap, timezone, the language runtime, middleware, directories and ownership |
+| 2 | Cloud and network | Security groups: port 22 from a bastion or a fixed address only, 80 and 443 public, and **the database port never public**. Also outbound rules, network ACLs, IAM roles, managed-database subnets, and the load balancer's health-check path |
+| 3 | Git access | A read-only deploy key, `known_hosts` set up in advance, which branches and tags to use, who owns the repository directory, and whether a shallow clone is right here |
+| 4 | Environment variables | Where the file lives, who owns it, its `600` mode, how it maps to the environment name, systemd's `EnvironmentFile`, and every required key. Note that **a missing key arrives as `null` and the application starts anyway** |
+| 5 | Security and keys | Getting and renewing the certificate, HSTS and cipher settings, making and placing signing and encryption keys with the right permissions, encryption at rest, and how to rotate a key while **accepting both old and new for a while** |
+| 6 | The edge | The server block, reverse proxy, WebSocket upgrade, body size, timeouts, static files and single-page fallback, then `nginx -t` and reload. **The E2E environment copies its proxy configuration from this chapter** |
+| 7 | Process management | The unit file, the restart policy, **every** process the product needs including workers and daemons, and where logs go and how they rotate |
+
+## Part II — every release
+
+Read every time. This is the part that gets worn out.
+
+| # | Chapter | Holds |
+| :-- | :-- | :-- |
+| 8 | Updating the code | The main sequence: fetch the tag, install dependencies, build, migrate, restart, reload. The **order**, and whether each stage interrupts service |
+| 9 | Migrations and seeds | Take the backup first, check the environment name, spread structural changes over releases, say how long a big table locks, and remember seeds only ever add rows |
+| 10 | Verification | One observable check per step — an HTTP status, a line in a log, a row in the database, a process state |
+| 11 | Rollback | How far back you can go, where the limit is, and the backup that sits right before it |
+| 12 | Checks left until production | What you could not test beforehand, and so have to test here |
+| 13 | Routine operations | Backups, certificate renewal checks, log rotation, monitoring, disk usage |
+| — | Appendix | What changes when CI runs these steps instead of a person |
+
+## The shape of one step
+
+````markdown
+### 8.3 Apply the migrations
+
+**Purpose** — bring the schema to the revision the new tag expects.
+
+**Preconditions** — 8.2 completed; the backup from 9.1 exists and its size is non-zero.
+
+```bash
+cd <app-dir> && NODE_ENV=production npx sequelize-cli db:migrate
+```
+
+**Expected output** — one `== <name>: migrated` line per pending migration, then no error. No
+pending migrations prints nothing and exits 0.
+
+**On failure** — do not re-run. Read `<app-dir>/logs/migrate.log`, and go to 11.2.
+
+**Rollback** — `db:migrate:undo` restores the previous revision **only if** the migration was
+reversible; the ones that are not are listed in chapter 9.
+
+**Interrupts service?** No, but a table over roughly a million rows locks for the duration —
+see 9.4.
+````
+
+Every step has all of these fields. Without **Expected output** nobody can tell whether it worked.
+Without **Interrupts service?** the operator finds out by watching the alerts.
+
+## Open questions
+
+Anything asked and not answered goes in a section of its own, with the chapter it blocks:
+
+```markdown
+## Open questions
+
+| # | Question | Blocks | Asked |
+| :-- | :-- | :-- | :-- |
+| Q1 | Does the managed database's automatic backup window overlap the release window? | 9.1 | 2026-08-23 |
+```
+
+Never replace one of these with an answer that merely sounds right. Someone runs a guess in a
+deployment document. Nobody reviews it.
+
+## What "out of scope" means here
+
+The document stops where your authority stops. Say plainly that it does not cover running the
+deployment, and does not cover building the pipeline. Then nobody waits for a workflow file that
+was never coming.

--- a/kit/skills/core/hc-deployment-document/references/interview.md
+++ b/kit/skills/core/hc-deployment-document/references/interview.md
@@ -1,0 +1,77 @@
+# Interview
+
+What to settle before drafting, the default behind each question, and what a different answer
+changes. Referenced from the procedure in [SKILL.md](../SKILL.md).
+
+## Running a round
+
+1. **Read the server and the repository first.** If the system is already running, you can read the
+   unit file, the edge configuration, the list of applied migrations and the deployed tag. Every one
+   you read is a question you do not have to ask.
+2. **Put the likely answer in the question.** "systemd, unless you are already on pm2?" takes one
+   word to answer. "How do you manage processes?" costs the operator a paragraph.
+3. **Ask what changes the document**, not what fills it in. If both answers give you the same
+   chapters, it is a placeholder value, not a question.
+4. **Five per round.** Group them by topic so one round can be answered in one sitting.
+5. **Write every answer into the profile table straight away.** An answer left in the conversation
+   gets asked again two rounds later.
+
+## The two that are always asked
+
+Neither has a safe default, and both change the shape of the whole document.
+
+| Question | Why no default is safe |
+| :-- | :-- |
+| **First build, or a release onto a system already serving traffic?** | It decides whether you write part I at all, and whether every step in part II has to work alongside the code already deployed. Guess "first build" and you write a document that breaks a live system. |
+| **How much downtime is allowed — none, a few minutes at night, or a maintenance page?** | It decides whether schema changes have to be spread over three releases, or whether you can stop, migrate and start. This is a business answer, not a technical one. |
+
+## The profile
+
+Each of these has a default. Ask the operator to confirm it, rather than asking an open question.
+
+| Question | Default | What a different answer changes |
+| :-- | :-- | :-- |
+| Hosting — cloud, VPS only, on-premises, hybrid | — *(always ask)* | Whether there is a security-group chapter at all, and every network assumption under it |
+| Which cloud — AWS / GCP / Azure / OCI / Sakura | — | Security groups, IAM, managed database, where the certificate comes from, whether TLS ends at a load balancer |
+| OS | Ubuntu LTS | Package manager, firewall command (`ufw` vs `firewalld`), service names |
+| Edge | nginx | Configuration layout, reload procedure, where certificates live |
+| Process manager | systemd | How to start, restart, log and recover. **pm2** swaps the unit file for an ecosystem file. **Docker** changes the whole release: build an image, tag it, and roll back by using the previous tag |
+| Database — your own, or managed | — | How backups work, where migrations run from, and who tunes the settings |
+| How code reaches the server | git on the server | Whether chapter 3 is a deploy key, or artifact delivery from CI |
+| Where secrets live | a `.env` file on the server | The environment-variable chapter, its permissions, and the rotation procedure |
+| TLS | Let's Encrypt | The certificate chapter and how it renews. If TLS ends at a load balancer, it leaves nginx entirely |
+
+## What not to ask
+
+- Anything you can read off the server or out of the repository.
+- Anything whose answer would not change a chapter, a step or an order.
+- Which directory, which unit name, which user. Suggest these with the profile and let the operator
+  correct you. Correcting is quicker than writing from scratch.
+
+## When the answer is "Docker"
+
+Choosing Docker is not just swapping one command for another. It changes the shape of the whole
+release:
+
+| Chapter | With systemd | With Docker |
+| :-- | :-- | :-- |
+| Code update | fetch a tag, install, build in place | build an image, tag it, push it, pull it |
+| Restart | `systemctl restart` | recreate the container from the new tag |
+| Rollback | check out the previous tag and rebuild | run the previous tag again — usually the fastest rollback there is |
+| Environment variables | `EnvironmentFile` | how the value reaches the container, and where it lives on the host |
+| Logs | journald | the container log driver and its rotation |
+
+Ask early. Find out while drafting and you rewrite part II.
+
+## When CI runs the steps
+
+The runbook still covers the server. One section says what changes when a pipeline runs the steps
+instead of a person.
+
+- **Keys** — a person uses their own key. A runner needs one of its own, and a way to revoke it.
+- **The user running the steps** — rewrite any step that assumes someone is logged in at a terminal.
+- **What replaces "check this looks right"** — turn each one into an automated check or a real
+  approval gate. You cannot just delete it.
+
+The pipeline's own configuration is out of scope. Say so in the document, so nobody waits for a
+workflow file that is never coming.

--- a/kit/skills/core/hc-deployment-document/references/ubuntu-nginx-profile.md
+++ b/kit/skills/core/hc-deployment-document/references/ubuntu-nginx-profile.md
@@ -1,0 +1,153 @@
+# The default profile: Ubuntu, nginx, systemd
+
+The default answers in full — the OS baseline, the firewall, the unit file, the server block,
+certificate renewal and log rotation. Referenced from the profile in [SKILL.md](../SKILL.md).
+
+> **These are examples.** `<app-dir>`, `<deploy-user>`, `<domain>` and the ports are placeholders,
+> filled in by chapter 0. Copy the shape, not the text.
+
+## OS baseline
+
+| Step | Note |
+| :-- | :-- |
+| A deploy user that is not `root`, with sudo limited to what the release needs | A release should not need full root. Chapter 0 lists what it does need |
+| SSH by key only — `PasswordAuthentication no`, `PermitRootLogin no` | Turn this on **after** checking the key works in a second session. Locking yourself out of a new server is the classic first-day outage |
+| Swap, sized for the instance | Without it, a build that briefly needs more memory is killed instead of slowed down |
+| Timezone and NTP set | Matching up logs across services depends on it, and so do scheduled jobs |
+| Automatic security upgrades | **Decide on purpose** whether they may restart services. The default can restart the application in the middle of a request |
+
+## Firewall
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow from <bastion-or-fixed-ip> to any port 22 proto tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+- **Never open port 22 to everyone.** Only a bastion or a fixed address.
+- **Never open the database port at all.** If the application and the database share a host, they
+  talk over loopback or a socket. If they do not, the security group handles it, not `ufw`.
+- Run `ufw status numbered` afterwards, and paste its output into the step as the expected
+  output.
+
+## The systemd unit
+
+```ini
+[Unit]
+Description=<app> application server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=<deploy-user>
+WorkingDirectory=<app-dir>
+EnvironmentFile=<app-dir>/.env
+ExecStart=/usr/bin/node server/index.js
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- **`EnvironmentFile` does not run shell syntax.** `KEY=$OTHER` arrives exactly as written. Quote
+  values with spaces, and take care with `#`.
+- **Use `Restart=on-failure`, not `always`.** `always` restarts a process that stopped on purpose,
+  turning a clean shutdown into a loop.
+- **Set `TimeoutStopSec` longer than your slowest request.** Otherwise `SIGKILL` arrives while a
+  request is still being served.
+- **Give every process its own unit.** Do not start workers and daemons from a shell next to the
+  application. They need the same restart policy and the same logging.
+
+## The nginx server block
+
+```nginx
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+server {
+  listen 443 ssl http2;
+  server_name <domain>;
+
+  ssl_certificate     /etc/letsencrypt/live/<domain>/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/<domain>/privkey.pem;
+
+  client_max_body_size 30m;
+  proxy_read_timeout   300s;
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $connection_upgrade;
+  }
+}
+
+server {
+  listen 80;
+  server_name <domain>;
+  return 301 https://$host$request_uri;
+}
+```
+
+**The local E2E environment copies its proxy configuration from this block.** Only three things
+differ there: TLS termination, the upstream address and `server_name`. Everything else is copied as
+it is, and that is what lets the E2E environment catch a bug in this file.
+
+- **One `proxy_set_header` inside a `location` throws away every header inherited from the `server`
+  block.** This is how a header quietly stops being forwarded on one route only.
+- **`$connection_upgrade` must be the mapped value**, not a plain `upgrade`, or keep-alive breaks
+  for normal requests.
+- Deploy with `nginx -t && sudo systemctl reload nginx`. Never `restart`.
+- Copy the old file before editing, so putting it back is a step and not a scramble.
+
+## Certificates
+
+```bash
+sudo certbot --nginx -d <domain>
+systemctl list-timers | grep certbot
+```
+
+- **Check the renewal timer exists**, and put that in the step. Getting the certificate works.
+  Renewing it is what fails quietly, ninety days later.
+- Put `certbot renew --dry-run` in chapter 13 as a routine check, not just at install time.
+- **If TLS ends at a load balancer, none of this belongs here.** The certificate lives with the
+  provider, nginx listens on 80, and `X-Forwarded-Proto` becomes the only way the application knows
+  whether the request was HTTPS. That makes it essential, not just informative.
+
+## Log rotation
+
+```
+<app-dir>/logs/*.log {
+  daily
+  rotate 14
+  compress
+  delaycompress
+  missingok
+  notifempty
+  copytruncate
+}
+```
+
+- Use `copytruncate` when the process holds the file open and has no reopen signal. If it does have
+  one, use `postrotate` with that signal instead — `copytruncate` can lose the lines written while
+  it copies.
+- If logs go to journald instead, `SystemMaxUse` in `journald.conf` sets the limit. It is **close to
+  unlimited by default**, and it really does fill disks months later.
+- Put a disk-usage check in chapter 13. A deployment that ran fine for six months and then stopped
+  is usually this.

--- a/kit/skills/core/hc-documentation/SKILL.md
+++ b/kit/skills/core/hc-documentation/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: hc-documentation
+description: "Documentation writing conventions. Referenced when updating or writing READMEs, design documents, comments, etc. Defines the language a document generated for a reader is written in, and the notation used when referring to class members, among other things."
+---
+
+# Documentation
+
+This gathers the conventions for writing documentation (READMEs, design documents, comments, etc.).
+
+- When writing or updating documentation, follow the conventions in this skill.
+- Follow this skill when writing or updating `SKILL.md` as well (referenced from the skill-updating convention).
+
+## Notation of Class Members
+
+- When referring to a class member within documentation, use the following notation.
+- Instance members are prefixed with `#`, static members with `.`.
+- **This skill is the governing source for this notation.** When another skill restates the same table, it aligns with the content here.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+- When attaching the class name, write it as in `SampleClass#extractValue()`.
+
+| notation | member |
+| :-- | :-- |
+| `SampleClass#extractValue()` | instance method of `SampleClass` |
+| `SampleClass.createValue()` | static method of `SampleClass` |
+
+## What language a document is written in
+
+- **A document written for a person to read is written in the language that person is using.** If
+  someone asks for a requirement definition in Japanese, the requirement definition is in Japanese.
+  If they ask in English, it is in English.
+- **An explicit instruction wins.** If the requester asks for a particular language, use that one,
+  whatever language the conversation is in.
+- **This skill is the governing source for this rule.** Other skills that produce a document refer
+  to it in one line rather than restating it, so there is one place to change.
+
+This covers anything generated for a reader — a requirement definition, a progress document, a
+review or audit report, an acceptance report, a deployment runbook.
+
+It does **not** cover the following, each of which has its own rule elsewhere.
+
+| Not covered | Rule, and where it lives |
+| :-- | :-- |
+| Code and identifiers | ASCII only, in the naming convention |
+| Comments in real code | English unless there is a reason otherwise, in the comment convention |
+| `LICENSE` | The original text, unchanged |
+| `SKILL.md` and its `references/` | English, so that every skill in a package reads the same way |
+
+**A README follows the project.** Some projects keep one file, some keep one per language
+(`README.md` alongside `README.ja.md`). Match what the repository already does rather than
+introducing a second pattern.
+
+**Why the rule is worth stating.** A document nobody can read has not been delivered. Writing a
+requirement definition in English for a team that works in Japanese means the one person who has to
+approve it reads it slowest — and approval is the step the document exists for.
+
+## Scope of application (applies beyond prose)
+
+- This notation applies not only to Markdown prose, but to **any text within implementation code that refers to a class member**. Specifically, this includes the following.
+  - **Error messages** (message strings in `throw new Error(...)`, etc.)
+  - **JSDoc / comments** (places within a member's description that refer to a member)
+- When dynamically embedding a class name, use the same notation. Prefix instance members with `#` and static members with `.`.
+
+```javascript
+// OK: instance method (the class name is resolved via this.constructor.name)
+throw new Error(`${this.constructor.name}#normalize() must be inherited`)
+
+// OK: static getter / static method (the class name is resolved via this.name)
+throw new Error(`${this.name}.get:rawSchema must be inherited`)
+throw new Error(`${this.name}.generateCredential() must be inherited`)
+```

--- a/kit/skills/core/hc-errors/SKILL.md
+++ b/kit/skills/core/hc-errors/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: hc-errors
+description: "Error-handling conventions. Covers returning null on failure from value-generating methods, the throw-message format for abstract members, and related policies."
+---
+
+# Shared: Errors
+
+Summarizes conventions for error handling.
+
+## Generation methods return null on failure
+
+- For a method that returns a generated value, return `null` rather than throwing an exception "when generation is not possible."
+- However, if there is a specific instruction to do so, implement it to throw an exception.
+
+```javascript
+// OK: return null when generation is not possible
+/**
+ * @param {{
+ *   length: number
+ * }} params - Parameters.
+ * @returns {string | null} Generated text, or null if it cannot be generated.
+ */
+generate ({
+  length,
+}) {
+  if (!Number.isInteger(length) || length < 0) {
+    return null
+  }
+
+  // ...
+}
+```
+
+## Throw message format for abstract members
+
+- When expressing, via `throw`, an abstract method or abstract getter that requires an override (inherited implementation) in a subclass, unify the `new Error()` message to the following format.
+
+```
+`${<class name>}<member-notation> must be inherited`
+```
+
+- `<member-notation>` follows "Notation of Class Members" from the documentation convention (instance method `#method()` / static getter `.get:name` / static method `.method()`, etc.).
+- `<class name>` is resolved dynamically, embedding the actual runtime class (subclass) name.
+  - Instance member: `this.constructor.name`
+  - Static member: `this.name` (in a static context, `this` is the class itself)
+- Unify the wording as `must be inherited`, with no trailing period (`.`).
+
+```javascript
+// OK: instance method (override required in subclass)
+normalizeValue () {
+  throw new Error(`${this.constructor.name}#normalizeValue() must be inherited`)
+}
+
+// OK: static getter
+static get rawSchema () {
+  throw new Error(`${this.name}.get:rawSchema must be inherited`)
+}
+
+// OK: static method
+static generateCredential () {
+  throw new Error(`${this.name}.generateCredential() must be inherited`)
+}
+```
+
+- Do not hard-code the class name. Hard-coding it will display the wrong class name when inherited by a subclass.
+
+```javascript
+// NG: class name is hard-coded (still displays "CompositeScalar" even in a subclass) + wording and trailing period are not unified
+static get boundSchema () {
+  throw new Error('CompositeScalar.get:boundSchema must be overridden.')
+}
+
+// OK: dynamically resolved, wording unified, no trailing period
+static get boundSchema () {
+  throw new Error(`${this.name}.get:boundSchema must be inherited`)
+}
+```

--- a/kit/skills/core/hc-functions/SKILL.md
+++ b/kit/skills/core/hc-functions/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: hc-functions
+description: "Conventions for functions. Function parameters follow method parameters: named arguments as a principle."
+---
+
+# Functions
+
+Conventions related to defining functions.
+
+## Named arguments as a principle
+
+- Function parameters follow method parameters: use named arguments as a principle.
+- That is, parameters are received as a single object with named arguments (destructuring), chopped down one property per line.
+- For detailed policy and exceptions, follow the method-definition convention, "Receive arguments as a single named-argument object".
+
+```javascript
+// NG: positional arguments
+function createColor (red, green, blue) {
+  // ...
+}
+
+// OK: a single named-argument object, chopped down
+function createColor ({
+  red,
+  green,
+  blue,
+}) {
+  // ...
+}
+```

--- a/kit/skills/core/hc-git-commit/SKILL.md
+++ b/kit/skills/core/hc-git-commit/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: hc-git-commit
+description: >
+  Conventions for git commits and the branches they land on. Covers what belongs in a single
+  commit and the order commits land in, the message format (imperative or Conventional
+  Commits), the verb vocabulary shared by both, and the trunk role with the subjects that open
+  and close a branch. The commands that gate a commit belong to the workflows convention. Use
+  before writing a commit message, before splitting a working tree into commits, and before
+  cutting or merging a branch.
+---
+
+# Git Commit
+
+Conventions for **what goes into one commit** and **how that commit is described**.
+
+These are two concerns decided at two different moments:
+
+- **Granularity** is decided *while working* — which changes get staged together.
+- **Format** is decided *at commit time* — how the staged change is worded.
+
+Granularity comes first. A badly scoped commit cannot be rescued by a well-written subject
+line, because the subject is then forced to describe several unrelated things at once.
+
+## Choosing the format
+
+Two message formats are in use across projects. They are **not interchangeable within a
+repository** — one repository uses one format throughout its history.
+
+Resolve which one applies, in this order.
+
+1. **The project's `CLAUDE.md`.** A project declares its format under a
+   `## Commit message format` heading:
+
+   ```markdown
+   ## Commit message format
+
+   - Format: imperative
+   ```
+
+   The accepted values are `imperative` and `conventional`.
+
+2. **The existing history**, when `CLAUDE.md` declares nothing. Read the recent non-merge
+   subjects and count how many carry a type prefix:
+
+   ```bash
+   git log --no-merges -n 30 --pretty=format:'%s'
+   ```
+
+   If **most** of them begin with `feat:` / `fix:` / `refactor:` / `test:` / `docs:` /
+   `chore:` (optionally with a scope, as in `feat(resolver):`), the project uses
+   conventional. Otherwise it uses imperative.
+
+3. **Default to imperative** when the history is too short to judge, as in a new repository.
+
+- Never mix the two formats within one repository. A history that is genuinely split down the
+  middle is a defect to raise with the user — it is not a licence to choose per commit.
+- When a project's resolved format contradicts what the user asks for in the moment, follow
+  the user for that commit, but tell them which format the repository otherwise uses.
+- Once resolved, follow the matching detail file:
+  [format-imperative.md](./references/format-imperative.md) or
+  [format-conventional.md](./references/format-conventional.md).
+
+### The resolved format governs what to write, never how to read
+
+A history may hold subjects in any other convention — written before the project settled on
+one, or by another team, or by hand in a hurry — and those commits are still the record of what
+happened. So when searching for where something changed, do not filter on the resolved format
+alone.
+
+```bash
+git log --format='%h %s' <range>                                            # no filter
+git log --format='%h %s' <range> | grep -P '^\S+ [a-z-]+(\([^)]*\))?!?: '   # type prefixes
+```
+
+Filter the subject line, as above, rather than reaching for `--grep`: that searches the whole
+message, so it also matches trailers such as `Co-Authored-By:`. And treat any subject filter as
+a shortcut rather than a guarantee — read the range's subjects, or its diff, without one before
+concluding that a change is not in the history.
+
+## Rules that apply to both formats
+
+### Subject line
+
+- The subject is a **single line**, and carries **no trailing period**.
+- Keep the subject **below 72 characters as much as possible**. This is a target, not a hard
+  limit — most subjects should clear it, and a minority legitimately will not.
+  - When a subject runs long, the usual cause is that the **commit is doing more than one
+    thing**. Reach for [granularity.md](./references/granularity.md) first: splitting the
+    commit shortens both subjects and is the fix that actually improves the history.
+  - The other legitimate cause is a **long but precise identifier**. Here the target yields:
+    naming `BaseRestfulApiLauncher#createResponseBodyParser()` in full is worth more than
+    hitting 72. Never truncate, abbreviate, or paraphrase an identifier to fit.
+  - What the target rules out is **padding** — the redundant trailing clause that restates
+    what the identifier already says. Cut the clause, not the identifier.
+- Describe **the change**, not the activity that produced it. `wip`, `save progress`,
+  `Update files`, and `Address feedback` describe a working session; they tell a later reader
+  nothing about what the tree now does differently. (Two commits are deliberate exceptions: the
+  branch-opening marker below, which carries no changes at all, and the throwaway save point in
+  [granularity.md](./references/granularity.md), which is deleted before anyone reads it.)
+- Do not record **how the change came to be asked for**: no "as requested", no "per review
+  comment", no tool attribution. Where the content itself came from is a different matter — that
+  belongs in the subject wherever it is part of what the work is.
+
+### The branch-opening marker commit
+
+A branch that will act as a trunk opens with an **empty commit** whose subject begins with
+`Start` — or with `Release`, on a `release/x.x.x` trunk. This is a deliberate convention, not a
+checkpoint or a placeholder.
+
+```bash
+# opening a long-lived dev branch
+git switch -c dev
+git commit --allow-empty -m 'Start dev'
+
+# opening a general branch that will carry sub-branches
+git switch -c feature/equip-tools-for-each-application
+git commit --allow-empty -m 'Start adding the skills installer'
+
+# opening a nested trunk: cut from the branch above, and carrying sub-branches of its own
+git switch -c update/the-domains-a-repository-selects
+git commit --allow-empty -m 'Start updating the domains a repository selects'
+```
+
+- It must be **empty** (`--allow-empty`). It exists to put a commit on a branch that has no
+  work on it yet, so there is nothing for it to carry. A `Start …` subject on a commit that
+  actually contains changes is not this convention — it is a mislabelled change.
+- It is the **first commit on the branch**, made immediately after branching.
+- **One per trunk, and none on a sub-branch.** The test is the branch's role: will other
+  branches be cut from this one and merged back into it? Where the answer is yes, the branch is
+  a trunk — that is what [branches.md](./references/branches.md) defines the word to mean, and
+  that definition is the whole of the condition.
+- **A nested trunk takes a marker of its own.** A general branch cut from `main` that then has
+  work split off it is a sub-branch and a trunk at once, and it is the trunk half the marker
+  answers to. Such a branch merges back locally, with no pull request anywhere in it, and it
+  still opens with `Start …`.
+- **Whether a pull request is ever opened decides nothing.** Where the merge does go through a
+  host, the marker buys a branch that can be reviewed before any code exists — but that is
+  something the commit makes possible, never the test for making one.
+- **`Start` is not a verb for resuming work mid-branch.** A branch already carrying commits has
+  nothing left to open.
+- The subject names **what is being started**, which depends on the kind of trunk.
+  - A **trunk that is one by name** is named directly: a `dev` branch opens with `Start dev`.
+    Here `dev` is the branch, not a placeholder word.
+  - A **general branch acting as a trunk** states the work it will carry — `Start adding the
+    skills installer`, `Start renaming kit/skills/_core/ to core/`. A later reader scanning the
+    log gets the branch's purpose for free.
+  - A **`release/x.x.x` trunk** is opened by its version alone: `Release 0.2.0`. The word
+    `Start` does not appear, because the version is the whole of what is being started.
+  - **Where the work carries content in from elsewhere, the marker names the origin** — `Start
+    migrating the mail templates from lunas-ec-cart-backend`. Stated once here, it covers every
+    commit on the branch, and the merge commit keeps it in the history after the branch is gone.
+- **The marker takes no type prefix, in either message format.** Repositories on Conventional
+  Commits write `Start dev`, not `chore: start dev`. The marker sits outside the format.
+
+### The merge commit
+
+A branch merges back into its trunk with `--no-ff`, and the merge commit that results carries a
+subject of its own.
+
+```
+Merge the classes of the skills installer
+Merge the core/ rename in the repository documents
+```
+
+- **It names the work, never the branch.** `Merge rename/FormElementClerk` says only what
+  `git log --graph` already shows, and the branch is deleted moments later. What it carried is
+  the part that has to survive it.
+- **It stands in for the message a host would have written.** A merge that goes through a pull
+  request is described for free — `Merge pull request #53 from …`. A merge made locally has no
+  such author, and this subject fills the gap.
+- **It takes no type prefix, in either message format**, for the same reason the branch-opening
+  marker takes none: it carries no change of its own. Repositories on Conventional Commits
+  write `Merge …`, not `chore: merge …`.
+- **A merge made through a pull request is left alone.** The host writes it, and no one here
+  chooses its wording.
+
+Which branch is a trunk, how the merge is made, and what becomes of the branch afterwards are in
+[branches.md](./references/branches.md).
+
+### Verbs
+
+A subject opens with a verb naming what actually happened. The vocabulary is the same in both
+message formats — capitalized on the imperative format, lowercase after the type on
+Conventional Commits.
+
+**A verb of two words joins into one where it sits in a single-token slot, and takes no hyphen
+in its place.** `Kick out`, `Tidy up`, `Turn on` and `Turn off` stay two words in a subject and
+become one before the slash of a branch name — `tidyup/the-environment-files` — and the same
+holds wherever a project puts this vocabulary in the `type:` slot of Conventional Commits rather
+than the types listed in [format-conventional.md](./references/format-conventional.md). The
+slash and the colon already end the token, so a hyphen inside it marks nothing.
+
+**The table below lists the verbs whose role is fixed, not the verbs a subject may use.** A row
+is there because choosing the wrong verb would lose something a later reader needs — whether a
+file survived, whether a class or one of its members was written, whether a constraint went one
+way or the other. Where a listed verb names what happened, it is the one to use, and no synonym
+substitutes for it. Where nothing listed names it, open the subject with the verb that does:
+`Name`, `Point`, `Follow`, `Keep` and their like fix no such distinction and need no row.
+
+| verb | use for |
+| :-- | :-- |
+| `Add` | a new file, member, case, or capability that did not exist |
+| `Declare` | a class written for the first time |
+| `Define` | a class member, function, or constant written for the first time |
+| `Author` | an AI element written for the first time — a skill, an agent, a command |
+| `Build` | markup written for the first time — a component, a page, an HTML skeleton |
+| `Fulfill` | a gap filled where something was declared but left short — a TODO, an unset option |
+| `Purge` | a whole file or folder deleted, with nothing replacing it |
+| `Kick out` | a part deleted from what stays — a class member, a section, an entry, a field |
+| `Tidy up` | a place brought into order, where nothing was removed and no behavior changed |
+| `Update` | an existing thing changed in itself, leaving it better than before |
+| `Retake` | an existing thing redone because what was there was poor, hurried, or a stopgap |
+| `Fix` | incorrect behavior corrected |
+| `Rename` | identifier changed, behavior untouched |
+| `Move` | relocation between files or directories, content untouched |
+| `Rearrange` | peers put into a different order — imports, declarations, cases, entries |
+| `Extract` | logic pulled out into its own member or module |
+| `Unify` | two members or modules folded into one |
+| `Optimize` | a change made for speed, behavior untouched |
+| `Use` | switching to a different existing mechanism |
+| `Allow` / `Prevent` | a constraint loosened or tightened |
+| `Turn on` / `Turn off` | a switch flipped — a boolean, a lint rule, a feature flag |
+| `Adjust` | a dial moved — a threshold, a limit, the options of a rule that stays on |
+| `Export` | public surface changed |
+| `Install` / `Uninstall` | a dependency the project takes on, or gives up |
+| `Start` | **empty** branch-opening marker only — see above |
+| `Release` | **empty** marker opening a `release/x.x.x` trunk only — see above |
+| `Merge` | **merge commits only** — see above |
+
+- **`Declare` is for the class itself; `Define` is for what is written inside or beside it** —
+  a member, a function, a constant. Both are the specific forms of `Add`, and where they apply,
+  `Add` is the vaguer choice. `Add` remains correct for everything else that did not exist
+  before — a test file, a case, a reference document.
+
+  ```
+  Declare SkillsInstaller to replace the installed skills
+  Define SkillsInstaller#replaceInstalledSkills() to swap the tree in one pass
+  Define SKILL_DOMAIN naming the domains a repository can select
+  Add tests for SkillsInstaller
+  ```
+
+- **`Author` is the `Declare` of an AI element.** A skill, an agent, a command — whatever is
+  read by the agent rather than run by the application, and installs under `.claude/`:
+  `Author scribe skill`. Like `Declare` and `Define` it is a specific form of `Add`, and where
+  it applies `Add` is the vaguer choice. Editing one that already exists is not `Author` — that
+  is `Update`, `Fulfill` or `Tidy up`, whichever names what was done.
+- **`Build` is the `Declare` of markup.** A component, a page, the HTML skeleton of one:
+  `Build TalkroomMessage component`, `Build HTML skeleton for pages/settings/security.vue`. It
+  is the fourth of the family — `Declare` for a class, `Define` for a member, `Author` for an
+  AI element, `Build` for markup — and each is a specific form of `Add`. **It never means
+  running a build.** `npm run build` produces output, and output is not what a subject
+  announces; a commit that changed the build's configuration changed a config, and takes the
+  verb for that.
+- **`Purge` and `Kick out` split on what survives.** `Purge` is for a file or a folder that is
+  gone whole — `Purge tests/legacy/OldValidator.js`, `Purge tests/legacy/`. `Kick out` takes the
+  shape `Kick out <what> from <where>`, because the point is that `<where>` is still there
+  without `<what>` — a member of a class, a section of a document, an entry of a manifest:
+  `Kick out main: from package.json`. The pair mirrors `Declare` and `Define`.
+- **`Tidy up` is the cleanup that is not a removal.** It takes the shape `Tidy up <where>` —
+  `Tidy up the environment files` — and covers stale naming, leftover duplication and disorder,
+  where naming each micro-change on its own would be noise. When the cleanup *is* a removal, the
+  verb is `Purge` or `Kick out`, however the branch that carries it happens to be named.
+  - **The test is that no responsibility moves.** A typo in a comment or a type, a formatting
+    correction, a blank line added or taken out, the parameter of every public function renamed
+    to `it` — the tree does the same thing before and after, and a reviewer confirms exactly
+    that. One identifier renamed on its own merits is `Rename`; a sweep that makes a whole
+    surface uniform is a tidy-up.
+  - **A type that was wrong over code that was right is a tidy-up, never a `Fix`.** The
+    implementation is what the tree runs, and it was doing its job; only the annotation beside
+    it was mistaken. `Fix` would say the behavior had been wrong, and a later reader could not
+    then tell that subject apart from one that repaired a real defect.
+  - **Reordering has its own verb.** Putting a set of peers into a different order is
+    `Rearrange`, not a tidy-up: `Rearrange imports for vue/core alphabetically`.
+- **`Rearrange` moves peers, and only peers.** Imports, declarations, cases, entries — a set
+  whose members stand at the same level, where the order is a matter of reading and nothing
+  else. Reordering control flow is not this: two `if` statements swapped is a behavior change
+  wearing the clothes of an ordering, and it takes the verb its behavior deserves. Relocating
+  something to another file is `Move`; `Rearrange` never crosses a file.
+- **`Update` and `Retake` split on what was there before.** `Update` carries a sound
+  implementation forward and leaves it giving something it did not give before — the gain is the
+  point. `Retake` replaces what was poor, hurried or a stopgap with what should have been there,
+  and claims no gain beyond that. Neither is `Fix`: that one is for behavior that was wrong,
+  where `Retake` is for an implementation that worked and was not good enough.
+- **A member's inputs and outputs are `Update`'s ground.** A parameter it now takes, a return
+  value it now gives — the member itself is what changed. That a parameter is something which
+  appeared does not make it `Add`: addition takes `Add` where what appeared stands as an item of
+  its own, such as a test case or a manifest entry. Whether the change breaks a caller is marked
+  by the format rather than the verb — Conventional Commits writes `!` with a `BREAKING CHANGE:`
+  trailer.
+- **`Fulfill` fills a gap that was already there; `Add` brings something that was not.** A test
+  left as a TODO, a JSDoc block without its `@returns`, an option a rule was never given, a
+  `package.json` field left blank — the place existed and was short, and the commit makes it
+  whole. Where what is covered is itself new, its tests arrive with it and that is `Add`.
+  Nothing is replaced either way, which is what separates `Fulfill` from `Update`, and nothing
+  was wrong, which separates it from `Fix`. An option that was set and then moved is `Adjust`;
+  an option that was never set is `Fulfill`.
+- **`Add` covers a whole new thing and a part added to one that stands.** A test file that did
+  not exist and one more case inside a file that did are both `Add`, so long as what they cover
+  is itself new — coverage that was owed is `Fulfill`. Addition is deliberately left unsplit: no
+  pair divides it the way `Purge` and `Kick out` divide deletion, because none is needed — the
+  subject names the thing added either way, and nothing a later reader wants is hidden by the
+  choice. Do not invent a verb for the partial case.
+
+  Nor reach for `Update` there. An item added inside something else is still an addition: `Add`
+  names what appeared, where `Update` names only the thing it appeared in. The more telling verb
+  wins, as `Declare` and `Define` win over `Add` where they apply.
+- **A word that needs several of these verbs to say what it covered is too vague for a row.**
+  That is the test every exclusion below comes from: name the operations the word spans, and if
+  the answer is more than one, a reader of the subject cannot tell which happened. It is not
+  about how the word feels — `Refine` and `Apply` feel precise and span four verbs each, where
+  `Purge` feels blunt and spans exactly one.
+- **`Change`, `Remove` and `Create` are the ambiguous trio, and the table carries none of
+  them.** Each is broad enough to cover whatever happened, so the subject narrows nothing, and
+  each has specific verbs here to be narrowed into.
+  - `Change` fits wherever any of the others would. A subject opening with it has said only
+    that the tree is not what it was.
+  - `Remove` reads the same whether a whole file went or one line inside it did — `Purge` and
+    `Kick out` split exactly that, and `Delete` is `Remove`'s twin in this.
+  - `Create` leaves open whether a class, one of its members, or something else arrived, which
+    `Declare`, `Define` and `Add` settle between them. `Make` is `Create`'s twin, and
+    `Make changes to syntax` is what it comes to.
+- **The table carries no `Refine` either.** It claims the thing got better without saying what
+  changed, so the reader is left with the writer's satisfaction and nothing else. Whatever the
+  improvement was, a listed verb names it: the wording redone is `Retake`, the formatting
+  straightened is `Tidy up`, the order put right is `Rearrange`, the thing itself carried
+  forward is `Update`.
+- **The table carries no `Migrate`.** Carrying content in from elsewhere is bracketed by the
+  branch, not repeated on every commit: the marker names the origin once — `Start migrating the
+  mail templates from lunas-ec-cart-backend` — and each commit inside then says what kind of
+  thing arrived, `Declare` or `Define` or `Add`. A subject reading `Migrate BaseInputValidator`
+  says less than `Declare BaseInputValidator` does, and the origin it gestures at is nowhere.
+- **The subject names the thing that changed, not the thing that was brought to it.** This is
+  why the table carries no `Apply`. `Apply flex layout to main-container` puts the layout in the
+  object and leaves `main-container` — the thing that is now different — in a trailing phrase.
+  And the word spans four verbs: enabling a module is `Install` or `Turn on`, switching to
+  another mechanism is `Use`, evening out the spacing is `Tidy up`, and
+  `Apply respective change to the branch-number usage` is the umbrella noun that
+  [granularity.md](./references/granularity.md) already turns away.
+- **The table carries no `Replace`.** It spans `Use`, where one mechanism gave way to another,
+  and `Retake` or `Update`, where a passage of prose did. It also invites a subject that names
+  only what was dropped — `Replace SCSS variables` says nothing about what stands there now,
+  where `Use CSS custom properties instead of SCSS variables` says both and puts the surviving
+  mechanism first.
+- **The table carries no `Implement` or `Enhance`.** Both name a whole feature's worth of work,
+  which is the scale of a Conventional Commits type and of a branch, not of one commit. A
+  repository on that format writes `feat`, and a trunk-scale branch is named `implement/xxx`;
+  the commits inside are finer than either, and each takes the verb for what it did.
+- **A verb that names the purpose is not a verb that names the change.** `Keep`, `Tell` and
+  `Point` read as precise and each spans several operations, so a reader is left with the
+  writer's aim and no way to know what was done.
+  - `Keep` covers a requirement the code was short of (`Fulfill`), a rule that had not existed
+    before (`Prevent`), and a passage newly written (`Add`) — one verb over three commits a
+    reader needs to tell apart.
+  - `Tell` covers the ground of `Fulfill`, where the reader was short of something, and of
+    `Add`, where the statement is new.
+  - `Point` covers `Retake` where a passage was replaced, `Update` where it gained, and `Use`
+    where a reference in code moved to another mechanism.
+  - `Optimize` and `Retake` name a motive as well, and keep their rows because the motive
+    settles which operation it was rather than standing in for it.
+- **`Extract` leaves the logic in the tree, in a home of its own.** The call site stays and
+  delegates to what was pulled out, which is what separates it from `Purge` and `Kick out` —
+  nothing was deleted. Relocating something intact is `Move`; `Extract` makes a new home out of
+  part of an existing one, and `Unify` is the same operation run backwards. `Cut out` is not
+  in the table for the reason `Remove` and `Delete` are not: it reads as excision, so the
+  subject leaves open whether the logic landed somewhere or went away.
+- **`Install` and `Uninstall` name the dependency, not the file that records it.** `Install
+  date-fns 4.1.0` and `Uninstall date-fns` say what the project now depends on, or no longer
+  does. Reaching instead for `Add`, or for `Kick out`, would describe an edit to `package.json`,
+  which is merely where the fact is written down. A version change to a dependency already
+  installed is `Update`.
+- **A subject describes a transition, never a state.** `Don't disable the action button when
+  the competition is completed` describes a state the code should hold; `Allow the action button
+  when the competition is completed` says the same change as a transition, and it completes
+  *"Applying this commit will …"*, which a negative cannot. So a restriction lifted is `Allow`,
+  never a negative.
+  - **This is why `Put` is not in the table.** `Put the settings at the bottom` names where
+    things sit once the commit is applied, not what the commit did. What it did was
+    `Rearrange`, or `Move`, or `Add`, and one of those three always fits.
+- **`Turn on` and `Turn off` name the switch, not what it permits.** `Turn off
+  jsdoc/require-jsdoc for tests in eslint.config.js` says which setting moved; `Allow` and
+  `Prevent` name the behavior that is now open or closed. Where both would be true, the switch
+  is the more telling of the two, because a reader can go and find it. A value that moved along
+  a scale is neither: that one is `Adjust`.
+  - **`Enable` and `Disable` are not in the table**, and for a different reason than the vague
+    words: each spans exactly one verb, which is `Turn on` and `Turn off`. A synonym of a
+    listed verb costs nothing to write and costs a reader twice — the history splits between
+    two spellings of one event, and whoever searches it for when a rule went off has to know
+    both.
+- **A setting changes in three degrees, and each has its own verb.** `Turn on` and `Turn off`
+  flip the switch. `Adjust` moves the dial while the switch stays where it is — `Adjust MaxFiles
+  to 20 in <config>`, `Adjust max-len to 120 in eslint.config.js`. `Update` is for the setting
+  that changed in itself rather than in degree — `Update jest version to 30.4.2 in
+  package.json`. `Adjust` carries no direction: a dial is as properly turned down as up, which
+  is why `Update`'s gain does not apply to it.
+- **`Start`, `Release` and `Merge` are reserved** for the commits that carry no change of their
+  own — the two branch-opening markers and the merge commit, all described above. A change that
+  folds two things into one takes `Unify`, never `Merge`, so that a merge commit stays
+  recognizable by its subject alone.
+
+### Referring to class members
+
+When a subject or body names a class member, use the project's documentation notation.
+Instance members are prefixed with `#`, static members with `.`.
+
+| notation | member |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+With the class name attached, write it as `SampleClass#extractValue()` or
+`SampleClass.createValue()`.
+
+```
+Update BaseRestfulApiLauncher#extendRequestHooks() to return fulfilled hooks
+Tidy up the JSDoc of BaseRestfulApiLauncher.get:ResponseBodyParser
+```
+
+This is the same notation used throughout documentation and error messages; see the
+documentation convention.
+
+### Body
+
+- The body is **optional**. Omit it when the subject already says everything — most small,
+  well-scoped commits need no body.
+- When present, separate it from the subject with **one blank line** and wrap it at
+  **72 characters**.
+- The body explains **why**, not what. The diff already shows what changed; what it cannot
+  show is the constraint, the rejected alternative, or the non-obvious consequence.
+- A ticket or issue identifier may appear in the body, but the body must still explain the
+  change **without** it. A reader who cannot open the ticket must still be given the
+  reason.
+
+### Trailers
+
+- Do not add attribution trailers (`Co-authored-by:`, `Generated-with:`, and similar) unless
+  the project explicitly asks for them.
+- **A change that forces callers to follow takes a `BREAKING CHANGE:` trailer**, and there the
+  body stops being optional: name what a caller relied on, and what it has to do instead. The
+  test is whether code that passed against the old surface still passes — a parameter added
+  without a default, a return value narrowed, a member gone. A surface widened compatibly is
+  not this.
+  - **The trailer carries it in either format.** A subject has room for what changed, not for
+    what it costs, and breakage is found with `git log --grep='BREAKING CHANGE'` rather than by
+    scanning subjects. Conventional Commits marks the subject as well, with `!` before the
+    colon; the imperative format adds no mark, and needs none.
+
+### Each commit stands alone
+
+- Order commits so that **no commit depends on a later one**. A reader checking out any single
+  commit should find a coherent tree.
+- **What must pass before a commit is not settled here.** Which commands run before a commit,
+  and which before the work is called complete, belongs to the workflows convention. This one
+  settles what goes into a commit, how it is worded, and the order the commits land in — never
+  whether a command's result permits the commit.
+
+## Granularity in one line
+
+One commit is **one decision a reviewer can accept or reject on its own**. If the subject
+needs the word "and" to be accurate, the commit is two commits.
+
+The full heuristic — what to split, what to keep together, and how to stage a mixed working
+tree — is in [granularity.md](./references/granularity.md).
+
+## Detail files
+
+- [branches.md](./references/branches.md) — the trunk role, naming a branch, merging it back
+- [granularity.md](./references/granularity.md) — what belongs in one commit, splitting a mixed working tree
+- [format-imperative.md](./references/format-imperative.md) — capitalized imperative subject, no type prefix
+- [format-conventional.md](./references/format-conventional.md) — Conventional Commits (`type: summary`)

--- a/kit/skills/core/hc-git-commit/references/branches.md
+++ b/kit/skills/core/hc-git-commit/references/branches.md
@@ -1,0 +1,105 @@
+# Branches
+
+Conventions for the branches a repository carries. Referenced from `SKILL.md`.
+
+## The trunk branch
+
+A **trunk branch** is one that other branches are cut from and merged back into.
+
+Four are trunks by name, in every repository.
+
+| branch | what it carries |
+| :-- | :-- |
+| `main` | the mainline every other branch descends from |
+| `release/x.x.x` | one version's work, until it merges into `main` |
+| `dev` | long-lived integration |
+| `env` | the initial environment setup |
+
+**Every other branch is a general branch, and takes the role rather than holding it.** A
+general branch behaves as a trunk for as long as work is split off it. The four above behave as
+trunks whether anything is outstanding against them or not.
+
+The shape of the name settles nothing. `release/x.x.x` is a trunk and
+`retake/save-of-UserRepository` is not, and the two are the same shape.
+
+- **Trunks nest.** A general branch cut from `main` that then has work split off it is both: a
+  sub-branch of `main`, and the trunk of what it carries. The role is held against a particular
+  branch, never held outright.
+  - **Each half brings its own obligations, and neither cancels the other.** Being a trunk, the
+    branch opens with the `Start …` marker described in `SKILL.md`; being a sub-branch, it
+    merges back into `main` once it is done. That the merge is made locally, with no pull
+    request to open early, takes nothing away from the marker.
+- **A sub-branch merges back into its trunk, and a trunk never merges into what it carries.**
+  The direction is the same at every level of the nesting.
+- **A trunk is where work arrives, not where work is done.** Nothing is committed to a trunk
+  directly: cut a branch for the change, commit it there, and merge it back. This holds for a
+  general branch from the moment it takes the role, and it holds on a trunk whose only commit so
+  far is its own opening marker — a trunk with nothing on it yet is still not a place to work.
+  - The exceptions are the two commits a trunk makes about itself rather than about the work:
+    the marker that opens it, and the `Merge …` commit that brings a sub-branch in. Both are
+    described in `SKILL.md`, and neither carries a change of its own.
+
+## Naming a general branch
+
+A general branch is named `<verb | category>/xxxx`. Before the slash goes a verb for what the
+branch does, or a category for what kind of work it is; after it, the name is free — an
+identifier may appear verbatim.
+
+```
+declare/AlphaClass
+define/sendMessage-of-AlphaClass
+rename/FormElementClerk
+fix/type-errors-reported-by-the-client-package
+install/date-fns-4.1.0
+tidyup/the-environment-files
+```
+
+**The name is written for whoever scans `git branch` while the work is still in flight**, so it
+is deliberately descriptive. Nothing reads it after the branch is gone.
+
+- **The verb is the word the branch's own commits would use, lowercased.** `Declare` names a
+  class and `Define` names a member, a function or a constant, which is why
+  `declare/AlphaClass` and `define/sendMessage-of-AlphaClass` say what they carry without any
+  further explanation. The verbs are listed in `SKILL.md`.
+  - **A verb of two words joins into one, with no hyphen** — `Tidy up` gives `tidyup/xxxx`,
+    `Kick out` gives `kickout/xxxx`, `Turn off` gives `turnoff/xxxx`. The slash ends the token,
+    so nothing inside it has to.
+- **A member is written `<member>-of-<class>`.** The slash is already spent on the verb, so what
+  is left spells the relation out instead of punctuating it.
+- **Work of a scale that will make the branch a trunk takes a category at a higher level of
+  abstraction** — `implement/xxx`, `setup/xxx`, `feature/xxx`, `retake/xxx`, `update/xxx`. A
+  branch that is about to have six branches cut from it cannot be named for one narrow verb
+  without lying about five of them.
+- **A sub-branch cut from a general branch acting as a trunk is named the same way**, and the
+  nesting adds no constraint of its own: `<verb | category>/xxxx`, free. The narrow verbs
+  belong here, where each branch really does carry one thing.
+
+## Merging back into a trunk
+
+- **Always `--no-ff`, never fast-forward.** A fast-forward leaves no commit a human can point
+  at: the branch's commits are strung onto the trunk's line, and the fact that they arrived
+  together, as one piece of work, stops being visible at all.
+- **Delete the branch once it is merged.** Its name was written for whoever watched the work in
+  flight, and that reader is gone. This includes a trunk that merges into another trunk —
+  `dev` and `env` are deleted once they land on `main`.
+  - **A trunk kept alive after it merged sits at the past of the trunk it merged into**, and
+    everything cut from it afterwards inherits that. Merging `origin/main` back in would
+    settle it, but re-cutting the branch settles the same thing without leaving a merge commit
+    that carries no work of its own:
+
+    ```bash
+    git branch -d dev
+    git switch -C dev origin/main
+    ```
+- **When two branches were cut from the same commit on a trunk, whichever merges second rebases
+  onto the trunk's new tip first.** The second branch then merges into the trunk as it now
+  stands, rather than reopening a line that was already closed.
+- **Every rebase in this scheme uses `-r` (`--rebase-merges`).**
+
+  ```bash
+  git rebase -r --onto <trunk's new tip> <the commit this branch was cut from> <branch>
+  ```
+
+  Without `-r`, `git rebase` drops every merge commit it replays. A branch that carried its own
+  sub-branches then arrives flattened, and the `--no-ff` merges inside it are gone — the exact
+  thing `--no-ff` was used to keep.

--- a/kit/skills/core/hc-git-commit/references/format-conventional.md
+++ b/kit/skills/core/hc-git-commit/references/format-conventional.md
@@ -1,0 +1,113 @@
+# Format: Conventional Commits
+
+The message format used when a project resolves to `conventional`. Referenced from `SKILL.md`.
+
+## Shape
+
+```
+<type>[(<scope>)]: <lowercase summary>
+```
+
+- **`type`** is lowercase, from the table below, and is required of every commit that carries a
+  change. **A commit that carries none takes no type** — the type describes a change, and there
+  is none to describe.
+  - Two commits are like this, both described in `SKILL.md`: the empty branch-opening `Start …`
+    marker, and the `Merge …` commit that closes a branch. Write `Start dev`, not
+    `chore: start dev`.
+  - A merge that had to resolve a conflict still takes none. What it carries is the adjustment
+    joining the two lines required, not a decision of its own.
+- **`scope`** is optional, lowercase, in parentheses — the area of the codebase affected.
+- A **colon and a single space** separate the prefix from the summary.
+- The **summary is lowercase** (unless it opens with an identifier that is itself capitalized)
+  and in the **imperative mood**, with **no trailing period**.
+
+A colon before the first space separates the type from the summary. Every other colon in a
+subject belongs to the class-member notation, where it always follows `#` or `.`:
+`docs: tidy up the JSDoc of BaseRestfulApiLauncher.get:ResponseBodyParser` carries one of each.
+The two never collide — one opens the subject, the other sits inside a member name.
+
+```
+feat: add LockEmployeeSignInInputValidator for employee sign-in validation
+fix: return 401 instead of 500 when the visa is expired
+refactor: update return types in LockClientMemberSignInMutationResolver
+test: add generateCommentFilesAssignments tests to client TaskCommentsQueryResolver
+feat(resolver): add unlockClientMemberSignIn mutation
+```
+
+## Types
+
+| type | use for |
+| :-- | :-- |
+| `feat` | a new feature added to the application or library |
+| `fix` | corrected behavior |
+| `refactor` | restructuring with no change in behavior |
+| `test` | tests added or changed, with no production-code change |
+| `docs` | documentation only |
+| `chore` | build config, dependencies, tooling |
+| `style` | formatting only, no code meaning changed |
+| `perf` | a change made for performance |
+
+- **A feature's internal parts take the same type as the feature.** A class only `Alpha` uses
+  is still part of what `Alpha` delivers, so it is `feat`, not `chore`. Judging visibility per
+  commit is the wrong moment for it — a class can become reachable later without any commit
+  changing. Which feature it serves is what the branch and its merge commit say; put it in the
+  summary (`feat: declare Beta for Alpha`) only where that context is missing.
+- The type describes **the change**, not the file it lands in. A bug fixed inside a test
+  helper is `fix`, not `test`.
+- `refactor` asserts that behavior did not change. If behavior changed, it is `feat` or `fix`
+  — and the two should have been separate commits in the first place. See the granularity
+  detail file.
+- When two types would both fit, the commit is doing two things. Split it.
+
+## Summary
+
+The summary follows the same substance rules as any other format: name the concrete thing that
+changed, in the imperative mood, using the class-member notation given in `SKILL.md`.
+
+**Its verb follows the shared table in `SKILL.md`** wherever that table fixes a role,
+lowercased to sit after the type: `feat: declare AlphaClass`, `refactor: extract the retry
+loop`. The vocabulary does not change between the two formats — only the capitalization and
+what precedes it do.
+
+The characteristic failure of this format is a **redundant trailing clause** that restates the
+identifier already named:
+
+```
+Bad:  feat: add LockEmployeeSignInInputValidator for employee sign-in validation
+Good: feat: add LockEmployeeSignInInputValidator
+
+Bad:  feat: implement LockClientMemberSignInMutationResolver for locking client member sign-in accounts
+Good: feat: add LockClientMemberSignInMutationResolver
+```
+
+The identifier already carries the purpose. Add a clause only when it says something the name
+does not.
+
+```
+Good: fix: reject empty clientMemberId before the resolver reaches the model
+```
+
+Related: `add` and `implement` are not two different things. Use `add`.
+
+## Breaking changes
+
+A breaking change is marked with `!` before the colon. The `BREAKING CHANGE:` trailer that
+explains it, and the body it sits under, are required of both formats — `SKILL.md` states that
+rule, and this format adds the subject marker on top of it.
+
+```
+feat(resolver)!: require clientMemberId on unlockClientMemberSignIn
+
+BREAKING CHANGE: unlockClientMemberSignIn previously resolved the member from
+the visa. Callers must now pass clientMemberId explicitly.
+```
+
+- Mark the break even when it feels minor. The marker is what downstream tooling and release
+  notes key on.
+
+## Scope
+
+- Use a scope only when the repository already uses scopes consistently. A history where a
+  quarter of commits carry one is worse than a history with none.
+- Scope names an **area**, not a file: `resolver`, `validator`, `model`, `job` — not
+  `LockEmployeeSignInInputValidator`, which belongs in the summary.

--- a/kit/skills/core/hc-git-commit/references/format-imperative.md
+++ b/kit/skills/core/hc-git-commit/references/format-imperative.md
@@ -1,0 +1,78 @@
+# Format: Imperative (No Type Prefix)
+
+The message format used when a project resolves to `imperative`. Referenced from `SKILL.md`.
+
+## Shape
+
+```
+<Capitalized imperative verb> <what changed>
+```
+
+- **Capitalized** first word.
+- **Imperative mood** — the verb reads as an instruction to the codebase, not as a report of
+  what was done. The test: the subject completes the sentence *"Applying this commit will
+  \_\_\_ ."*
+- **No type prefix**, no scope, no bracketed tag.
+- **No trailing period.**
+
+```
+Export FormElementInspector via main-export
+Add correctness checks reference for code-review skill
+Rename VariablesValidator variable name to ValueHashValidator in BaseFormElementClerk
+Tidy up the JSDoc of BaseRestfulApiLauncher.get:ResponseBodyParser
+Allow the action button when the competition is completed
+Add `dist/` to .gitignore
+```
+
+## Mood
+
+Past tense and gerunds are the most common slip.
+
+```
+Bad:  Added validator for employee sign-in
+Bad:  Adding validator for employee sign-in
+Bad:  Adds validator for employee sign-in
+Good: Add validator for employee sign-in
+```
+
+## Verbs
+
+Where the shared table in `SKILL.md` fixes a verb's role, the subject uses that verb. Where the
+table fixes none for what happened, any verb that names it accurately will do — a precise verb
+often removes the need for a body.
+
+- Prefer the specific verb over `Update`. `Update BaseFormElementClerk` says almost nothing;
+  `Rename VariablesValidator to ValueHashValidator in BaseFormElementClerk` says all of it.
+- `Modify` is almost always the wrong verb — some more precise verb applies. `Change` is ruled
+  out outright, with the rest of the ambiguous trio, in the table itself.
+
+## Naming the target
+
+Name the concrete thing that changed, using the class-member notation given in `SKILL.md`.
+
+```
+Bad:  Tidy up the launcher
+Good: Tidy up the JSDoc of BaseRestfulApiLauncher.get:ResponseBodyParser
+
+Bad:  Update tests
+Good: Update test for BaseRestfulApiLauncher#extendRequestHooks()
+
+Bad:  Improve card layout
+Good: Use grid layout to make sure children doesn't overflow
+```
+
+Backtick literal file names, flags, and values when they appear in a subject
+(`` `.furo-env.example` ``, `` `.directory-keeper` ``).
+
+## Bodies
+
+Most commits in this format carry no body. Add one only when the *why* cannot be worked out
+from the subject and the diff together.
+
+```
+Use late registration date unless it doesn't exist
+
+The competition schedule may omit the late registration window entirely, in
+which case the regular registration end date is authoritative. Falling back
+the other way showed a closed competition as still open.
+```

--- a/kit/skills/core/hc-git-commit/references/granularity.md
+++ b/kit/skills/core/hc-git-commit/references/granularity.md
@@ -1,0 +1,144 @@
+# Granularity (What Belongs in One Commit)
+
+Conventions for deciding which changes are staged together. Referenced from `SKILL.md`.
+
+This is decided **while working**, not at commit time. By the time the work is finished and
+the tree holds six unrelated edits, the cheap moment to have made the decision has passed.
+
+## Principle: one commit is one decision
+
+A commit is the unit a reviewer accepts or rejects. It should therefore contain **exactly one
+decision** — one behavior change, one rename, one new artifact — and everything required to
+make that decision coherent, and nothing else.
+
+Two consequences follow.
+
+- A reviewer who disagrees with one decision can reject that commit **without** undoing
+  unrelated work that happened to travel with it.
+- A later reader bisecting for a regression lands on a commit that changes **one** thing, so
+  the answer to "what broke it" is the commit itself, not a subset of it.
+
+## The "and" test
+
+If an accurate subject line needs the word "and", the commit is two commits.
+
+```
+Bad:  Add LockEmployeeSignInInputValidator and tidy up an unrelated JSDoc typo
+Good: Add LockEmployeeSignInInputValidator
+      Tidy up the JSDoc of EmployeeSignInMutationResolver#resolve()
+```
+
+The same applies to a subject that reaches for a vague umbrella noun to cover several
+changes — `Update auth handling`, `Various fixes`, `Cleanup`. The umbrella is the "and" in
+disguise.
+
+## Scale
+
+Keep commits small. **1 to 4 files** is the working range, and a single-file commit is a
+perfectly normal unit of work. A commit touching more than a handful of files is something to
+justify, not a default to settle into.
+
+Large commits are legitimate in a few cases — a mechanical rename across many files, a
+generated artifact, an initial scaffold. What makes them legitimate is that they are still
+**one decision**, and the reviewer only has to agree with that one decision once.
+
+## What to split
+
+| Split these apart | Why |
+| :-- | :-- |
+| Implementation and its tests | The test commit states what the implementation is expected to do, and reads as its own reviewable claim. Reviewing them separately keeps a weak test from being waved through on the strength of the code beside it. |
+| Refactor and behavior change | A refactor is reviewed by confirming behavior did **not** change. Mixed together, the reviewer cannot tell which lines were meant to alter behavior. |
+| Mechanical rename and logic edit | A rename is verified by scanning that it is uniform. One hand-edited line hidden among 200 renamed ones is invisible. |
+| Formatting or lint fixes and substance | Whitespace churn buries the two lines that matter. |
+| Dependency bumps and code that uses them | The bump is a separate risk with a separate rollback. |
+| Generated artifacts (`package-lock.json`, generated types) and hand-written source | Generated diffs are large and unreviewable; keeping them separate keeps the source commit readable. |
+| Unrelated files that happen to be dirty | They are unrelated. This is the most common cause of an accidental umbrella commit. |
+
+Registering a new artifact in an index or export barrel is its own commit as well. Adding the
+class and exporting it are two decisions, and the export is the one with a public-surface
+consequence.
+
+**A class's tests are committed before its implementation.** The order is what makes the split
+worth having: the test commit states what the class is expected to do, and the implementation
+commit is the one that makes the statement true. Committed the other way round, the tests only
+confirm what already worked, and there is no commit at which the claim stands on its own to be
+reviewed. This is test-driven development written into the history rather than into the editor.
+
+## What to keep together
+
+- A change and the **type annotations or JSDoc that describe it**. A signature and its
+  documented contract are one decision; splitting them leaves a commit whose documentation
+  contradicts its code.
+- A change and whatever is **required for the commit to hold together on its own** at that
+  point. If splitting would produce a commit that refers to something that is not there yet —
+  a call to a member the next commit defines, an import of a file it adds — the split is in the
+  wrong place. Find a different seam rather than committing the dangling reference.
+  - **A seam is not only a line between files. An order is a seam too.** One breaking order
+    proves nothing about the rest: the same change split the other way round often passes
+    through every intermediate state intact. Before concluding that no seam exists, reverse the
+    order and try again.
+  - **Take a removal apart from the outside in** — the callers first, then the registration,
+    then the thing itself. Each step deletes something nothing else points at any more, so no
+    intermediate state refers to what is gone. Going the other way breaks at the first commit,
+    which is what makes a removal look unsplittable when it is not.
+  - Retiring a check that a CI workflow runs, an npm script registers, and a script file
+    implements is three commits, and taken in this order not one of them leaves a dangling
+    reference behind:
+
+    ```
+    Kick out the levers reference check from the CI workflow
+    Kick out check:levers from package.json
+    Purge scripts/check-levers.mjs
+    ```
+
+    The subjects come apart as cleanly as the commits do, because `SKILL.md` gives a removal
+    two verbs instead of one — `Kick out <what> from <where>` for the file that stays without
+    it, and `Purge <path>` for the file that goes. That pair is the tool for splitting one
+    removal across several commits; a single `Remove` would hide the seam it makes visible.
+- A rename and **every call site it touches**. Half a rename is a broken tree.
+
+## Staging a mixed working tree
+
+When the tree already holds several unrelated changes, do not resolve it by committing
+everything at once.
+
+```bash
+git add -p            # stage one decision's hunks at a time
+git diff --cached     # confirm what is actually staged before committing
+git diff              # confirm what is being left for the next commit
+```
+
+- Never `git add -A` or `git add .` without first checking what that sweeps in. Untracked
+  scratch files, editor artifacts, and `.env` variants are picked up this way.
+- When hunks for two decisions are interleaved in the same file, stage the first, commit, and
+  then stage the second. `git add -p` splits hunks with `s` and edits them with `e`.
+
+## Anti-patterns
+
+- **Checkpoint commits.** `wip`, `save progress`, `saving` — a commit holding real changes
+  whose message records that time passed rather than what changed. If a checkpoint is needed
+  mid-work, use `git stash` or a local branch, and squash before the work is shared.
+  - This does **not** apply to the branch-opening `Start …` marker described in `SKILL.md`.
+    That commit is deliberately empty, so it makes no claim about granularity at all — there
+    is no change in it to have scoped correctly.
+  - Nor to the `Merge …` commit that closes a branch. It carries no change of its own either.
+    What a reviewer weighs there is the branch it brings in, and that was already scoped commit
+    by commit inside the branch.
+  - Nor to a commit made **on the premise that it is deleted right away** — a save point taken
+    only so that an operation needing a clean tree can run, undone by `git reset --soft`, by
+    `git commit --amend`, or by a squash the moment it has served that purpose. **Its message
+    is free.** Every convention on a subject exists to tell a later reader what changed, and
+    this commit is gone before there is one: `saving-20260821-1530` is as good a subject as
+    any, no verb from the vocabulary in `SKILL.md` has to fit it, and the changes in it are
+    left undivided.
+    - **The premise is what buys the freedom, so the premise has to hold.** A commit still
+      there when the work is shared was never one of these, whatever was intended when it was
+      made. Delete it before the branch goes out, or write it as any other commit.
+- **End-of-day dumps.** A single commit holding everything touched since morning is the
+  default outcome of never deciding granularity. Decide it while working.
+- **Typo-fix follow-ups on unpushed work.** A `Fix typo` commit immediately after the commit
+  that introduced the typo is noise. Fold it in with `git commit --amend` — but only while
+  the commit is **unpushed**. Once pushed, a separate fix commit is correct.
+- **Splitting past the point of coherence.** A commit left referring to what is not there yet,
+  so that the "one decision" rule could be honored more purely, has traded a real property for
+  a cosmetic one.

--- a/kit/skills/core/hc-implementation-progress/SKILL.md
+++ b/kit/skills/core/hc-implementation-progress/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: hc-implementation-progress
+description: >
+  Make the state of an in-flight implementation visible, in a progress document anchored to the
+  requirement ids of the feature being built — a status per requirement, advanced only against
+  recorded evidence, mirrored by the session's todo list. Use this skill whenever implementing a
+  defined feature spans more than one work item or session, or whenever the user asks how far
+  along the work is or what is blocked.
+---
+
+# Implementation Progress
+
+A skill for keeping the progress of an implementation **visible and truthful** while the
+implementation is happening.
+
+Progress is tracked in two places at once, and they serve different purposes.
+
+| Where | Lifetime | Purpose |
+| :-- | :-- | :-- |
+| `docs/features/<feature-slug>/progress.md` | Survives sessions, reviewed in git | The record of what is done and on what evidence |
+| The session's todo list | The current session only | The working slice — what is being touched right now |
+
+The document is the source of truth. The todo list is a view of the part of it that is
+currently active.
+
+## Core principle: progress is measured from evidence, not from effort
+
+A status describes **what has been verified**, never how much work has gone in. "Nearly done"
+is not a state; either the acceptance criteria hold and there is something that shows it, or
+they do not.
+
+- Advancing a status requires a recorded piece of evidence — a passing test, a command output,
+  a file path, a screen that was exercised.
+- Effort spent, code written and lines changed are not evidence and never move a status.
+- **A status that was advanced without evidence is a false report.** Everything downstream —
+  the review phase, the release decision — is made from this document.
+
+## Status set
+
+| Status | Meaning | Entered when |
+| :-- | :-- | :-- |
+| `TODO` | Not started | The requirement is in the approved document and nothing has been written for it |
+| `WIP` | Being implemented now | Work on it has actually begun in this session |
+| `BLOCKED` | Cannot proceed | Something outside the current work prevents it; the blocker is recorded |
+| `REVIEW` | Implemented, not yet verified | The code exists but its acceptance criteria have not all been checked |
+| `DONE` | Implemented and verified | Every acceptance criterion of the requirement has been checked and the evidence is recorded |
+| `WITHDRAWN` | No longer required | The requirement was withdrawn upstream; kept so the id is never reused |
+
+- The full transition rules, including what counts as evidence for each transition, are in
+  [status-rules.md](./references/status-rules.md).
+- `DONE` is the only status that counts as complete. `REVIEW` is not "basically done" — it is
+  the status of code nobody has verified yet.
+
+## One requirement in progress at a time
+
+- At most one requirement is `WIP`. Starting a second means the first goes back to `TODO` or
+  forward to `REVIEW` — not silently left half-open.
+- The exception is a requirement that cannot be finished without another one; in that case the
+  dependent one is `BLOCKED` with the blocking id recorded, not `WIP`.
+- The reason is not tidiness: several simultaneous `WIP` entries make the document unable to
+  answer "what would be lost if this stopped right now", which is the question it exists for.
+
+## Update at the moment the status changes
+
+- The document is edited **when the status changes**, not at the end of the task, not at the end
+  of the session.
+- The cost of the rule is one small edit; the cost of breaking it is a session that ends with
+  work that nothing records.
+- A batch of status changes written at the end is written from memory, and memory is exactly
+  what this document replaces.
+
+## Keeping the todo list in step
+
+- One todo item per requirement that is `WIP` or `BLOCKED`, named with the requirement id first:
+  `REQ-02 — failed attempt limit`.
+- Work that is not a requirement (setting up a fixture, reading a library) may be a todo item,
+  but never becomes a row in the progress document. The document's rows are requirement ids and
+  nothing else.
+- When a todo item completes, update the document first, then the todo list. In that order the
+  two can never disagree in the direction that matters.
+
+## Reporting progress to the user
+
+When asked how far along the work is, answer from the document, not from recollection. Read the
+file, then give:
+
+1. One line — `REQ done / total (percent)`, plus the count blocked if any.
+2. The status table.
+3. What is happening right now, and what is blocking anything blocked.
+
+Write the document, and this summary, in the language the reader is using, as the documentation
+convention requires of any document generated for a reader.
+
+```
+Progress: 7/12 done (58%), 1 blocked
+
+| ID | Requirement | Status | Evidence |
+| :-- | :-- | :-- | :-- |
+| REQ-01 | Sign-in with email and password | DONE | tests/__tests__/.../SignInMutationResolver.js |
+| REQ-02 | Failed attempts are limited | WIP | — |
+| REQ-03 | Sign-in response time | BLOCKED | needs the load-test environment |
+```
+
+- The percentage counts `DONE` over the total of requirements that are not `WITHDRAWN`.
+- **Never round a percentage upward and never report a partially-implemented requirement as
+  done.** A requirement is one unit; there is no half.
+- If the document does not exist yet for a feature that is already being implemented, say so
+  rather than reconstructing a plausible history — then create it from the requirement
+  document's ids, with every unverified requirement at `REVIEW` or `TODO`.
+
+## Resuming in a later session
+
+1. Read `docs/features/<feature-slug>/progress.md` before touching any code.
+2. Re-verify anything at `WIP` — its state is unknown, because the session that set it ended
+   without closing it. Treat `WIP` on entry as "unknown, inspect it".
+3. Re-create the todo list from the `WIP` and `BLOCKED` rows.
+4. Only then continue.
+
+Never reconstruct progress by reading the diff or the commit log. Those show what changed, not
+what was verified.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Instead |
+| :-- | :-- | :-- |
+| Marking `DONE` when the code is written | Written is not verified; the review phase then finds "finished" work that does not work | `REVIEW` until every acceptance criterion is checked |
+| Marking `DONE` on a manual check because the requirement's test is failing | The red test is part of the unfinished work; the row then reads green while the suite reads red | Fix the test, re-run it, then advance the row |
+| Percentage estimated by feel ("about 80%") | Cannot be checked, and is always optimistic | Count `DONE` rows over total rows |
+| A progress row that is not a requirement id | Nothing downstream can point at it, and the total stops meaning anything | Requirement ids only; other work lives in the todo list |
+| Updating the document at the end of the session | The one session that ends unexpectedly loses everything | Update at each status change |
+| Several requirements left `WIP` at once | The document can no longer say what is actually in flight | One `WIP`; the rest go back to `TODO` or on to `REVIEW` |
+| Deleting a withdrawn requirement's row | Its id looks free and gets reused, invalidating older references | `WITHDRAWN` with a reason; the row stays |
+| Answering "how far along?" from memory | The answer drifts from the record, and the record is what others read | Read the file, then answer |
+
+## Detail files
+
+- [status-rules.md](./references/status-rules.md) — the transition rules, what counts as
+  evidence for each transition, and how to handle blockers.
+- [document-template.md](./references/document-template.md) — the progress document template
+  and the rules for each field.

--- a/kit/skills/core/hc-implementation-progress/references/document-template.md
+++ b/kit/skills/core/hc-implementation-progress/references/document-template.md
@@ -1,0 +1,111 @@
+# Document Template
+
+The template for `docs/features/<feature-slug>/progress.md`, and the rules for each field.
+
+## Template
+
+````markdown
+# <Feature name> — Progress
+
+| Field | Value |
+| :-- | :-- |
+| Feature slug | `<feature-slug>` |
+| Requirements | `./requirements.md` |
+| Done | 0 / 0 (0%) |
+| In progress | — |
+| Last updated | YYYY-MM-DD |
+
+## Status
+
+| ID | Requirement | Status | Evidence |
+| :-- | :-- | :-- | :-- |
+| REQ-01 | <short title, copied from the requirement document> | TODO | — |
+
+## Blockers
+
+| ID | Blocked by | What would unblock it |
+| :-- | :-- | :-- |
+| REQ-nn | <the blocker> | <the action or decision needed> |
+
+## Change log
+
+| Date | ID | Change | Evidence |
+| :-- | :-- | :-- | :-- |
+| YYYY-MM-DD | REQ-01 | TODO → WIP | — |
+````
+
+## Field rules
+
+### Header
+
+- `Requirements` points at the requirement definition document in the same directory. It is a
+  relative path within the feature directory, so it survives the directory being moved.
+- `Done` is `<count of DONE> / <count of requirements that are not WITHDRAWN>` with the
+  percentage in parentheses, rounded down. Recomputed on every edit — a stale header is the one
+  thing a reader will trust without checking.
+- `In progress` names the single `WIP` requirement id, or `—`.
+
+### Status table
+
+- One row per requirement id in the requirement document, including `WITHDRAWN` ones. No other
+  rows.
+- The order follows the requirement document, and never changes.
+- `Requirement` repeats the short title so the table is readable on its own. If the title
+  changes upstream, update it here.
+- `Evidence` holds the evidence for the current status, in the form given by the status rules —
+  a test path, a command and its result, or `—` for statuses that require none.
+- A row whose evidence does not fit in the cell keeps a one-line summary in the cell and the
+  detail in the change log.
+
+### Blockers table
+
+- Only rows currently at `BLOCKED`. Resolved blockers move to the change log and leave the
+  table.
+- `Blocked by` uses a requirement id when the blocker is another requirement in this feature.
+
+### Change log
+
+- One row per status transition, in chronological order. This is the audit trail: the status
+  table says where things stand, the change log says how they got there.
+- The `Evidence` column repeats what justified the transition. For `REVIEW → DONE`, list every
+  acceptance criterion id and what verified it.
+
+## Worked example
+
+````markdown
+# Account Sign-in — Progress
+
+| Field | Value |
+| :-- | :-- |
+| Feature slug | `account-sign-in` |
+| Requirements | `./requirements.md` |
+| Done | 1 / 3 (33%) |
+| In progress | REQ-02 |
+| Last updated | 2026-08-02 |
+
+## Status
+
+| ID | Requirement | Status | Evidence |
+| :-- | :-- | :-- | :-- |
+| REQ-01 | Sign-in with email and password | DONE | tests/__tests__/server/graphql/resolvers/customer/actual/mutations/SignInMutationResolver.js |
+| REQ-02 | Failed attempts are limited | WIP | — |
+| REQ-03 | Sign-in response time | BLOCKED | — |
+
+## Blockers
+
+| ID | Blocked by | What would unblock it |
+| :-- | :-- | :-- |
+| REQ-03 | No environment to run 100 concurrent requests against | The load-test environment, or the requester accepting a single-request measurement |
+
+## Change log
+
+| Date | ID | Change | Evidence |
+| :-- | :-- | :-- | :-- |
+| 2026-08-02 | REQ-01 | TODO → WIP | — |
+| 2026-08-02 | REQ-01 | WIP → REVIEW | SignInMutationResolver.js, SignInInputValidator.js |
+| 2026-08-02 | REQ-01 | REVIEW → WIP | AC3 failed — an unregistered address returned `account-not-found`, not `invalid-credentials` |
+| 2026-08-02 | REQ-01 | WIP → REVIEW | The unknown-address path now returns the same error |
+| 2026-08-02 | REQ-01 | REVIEW → DONE | AC1, AC2, AC3 each covered by a case in SignInMutationResolver.js; suite passed |
+| 2026-08-02 | REQ-02 | TODO → WIP | — |
+| 2026-08-02 | REQ-03 | TODO → BLOCKED | No load-test environment available |
+````

--- a/kit/skills/core/hc-implementation-progress/references/status-rules.md
+++ b/kit/skills/core/hc-implementation-progress/references/status-rules.md
@@ -1,0 +1,96 @@
+# Status Rules
+
+The conditions for every status transition, what counts as evidence, and how blockers are
+handled.
+
+## Permitted transitions
+
+```
+TODO ──▶ WIP ──▶ REVIEW ──▶ DONE
+  ▲       │         │         │
+  └───────┘         └──▶ WIP  │      (a criterion failed; back to implementing)
+          ▲                   │
+          └───────────────────┘      (re-opened: a verified requirement regressed)
+
+any ──▶ BLOCKED ──▶ (the status it came from)
+any ──▶ WITHDRAWN                    (only when withdrawn in the requirement document)
+```
+
+- `TODO → DONE` and `WIP → DONE` are not permitted. Everything passes through `REVIEW`, because
+  `REVIEW → DONE` is the transition where verification happens.
+- `DONE → WIP` is the **only** transition out of `DONE`, it is called re-opening, and it always
+  carries a change-log entry saying what was observed. A requirement that was verified and is
+  now broken is a regression, and the record must show that it happened. Silently setting a
+  `DONE` row back to `TODO`, or editing its evidence, erases the regression.
+- `WITHDRAWN` is only set because the requirement document withdrew the requirement. Never
+  withdraw a requirement to avoid implementing it.
+
+## Conditions per transition
+
+| Transition | Condition | Evidence recorded |
+| :-- | :-- | :-- |
+| `TODO → WIP` | Work on this requirement actually starts, and no other requirement is `WIP` | — (evidence is not required to start) |
+| `WIP → REVIEW` | The implementation for every acceptance criterion of the requirement exists | The paths of the files that implement it |
+| `REVIEW → DONE` | Every acceptance criterion has been checked and observed to hold | Per criterion: the test that covers it, or the command and its result |
+| `REVIEW → WIP` | A criterion was checked and did not hold | The criterion id and what was observed instead |
+| `DONE → WIP` | A requirement that was verified no longer holds | What was observed, and which acceptance criterion it breaks |
+| `any → BLOCKED` | Something outside this requirement prevents progress | What is blocking, and what would unblock it |
+| `BLOCKED → previous` | The blocker is resolved | What resolved it |
+| `WIP → TODO` | Work is being set aside to start something else | — (the row must not be left `WIP`) |
+
+## What counts as evidence
+
+Evidence must be something another person can check without asking the author.
+
+| Counts as evidence | Does not count |
+| :-- | :-- |
+| The path of a test that covers the criterion, and the fact that the suite it belongs to passed | "The tests pass" with no path |
+| A command and the output that shows the outcome | "I ran it and it worked" |
+| A stored record, response body or screen that shows the outcome | "It should work now" |
+| A migration applied and the resulting schema | The migration file having been written |
+
+- Evidence for a `REVIEW → DONE` transition must cover **every** acceptance criterion of the
+  requirement, not the requirement in general. A requirement with three criteria and evidence
+  for two stays at `REVIEW`.
+- Where the criterion is covered by an automated test, name the test file. Where it is not,
+  record the command that was run and what it produced. A criterion verified only by reading the
+  code is not verified; note it as such and leave the row at `REVIEW`.
+- **A requirement whose criterion has an automated test cannot reach `DONE` while that test is
+  red** — no matter what a manual check shows. The test is part of what was built: a red test
+  for the requirement means the requirement is not finished, even when the behavior it is
+  aimed at happens to be correct. Fix the test, re-run it, then advance the row. Reaching for a
+  manual command *because* the test is failing is the loophole this rule closes; the manual path
+  exists for criteria that have no test, not for criteria whose test is broken.
+
+## Blockers
+
+- A blocked row records three things: the blocker, what would unblock it, and who or what it
+  depends on.
+- A dependency on another requirement in the same feature is recorded by id: `blocked by
+  REQ-04`. This is what makes the ordering of the work visible.
+- A blocker that is nobody's action — an unanswered question about the requirement itself —
+  belongs back in the requirement document as an open question. Record it in both places: the
+  progress row is `BLOCKED`, and the requirement document carries the question.
+- Never work around a blocker by narrowing the requirement. Narrowing a requirement is a change
+  to the requirement document, decided by the requester.
+
+## Handling requirements discovered during implementation
+
+Implementation regularly turns up something the requirement document does not cover. Do not
+invent a progress row for it.
+
+| What was found | What to do |
+| :-- | :-- |
+| A necessary behavior nobody specified | Raise it as a new requirement in the requirement document; only then does it get a progress row |
+| An existing defect, unrelated to this feature | Note it and report it; it is not part of this feature's progress |
+| Work that is a means to an end (refactor, fixture, tooling) | A todo item, never a progress row — it has no acceptance criteria to verify against |
+
+## Reading a document written by an earlier session
+
+- `WIP` on entry means "unknown". The session that set it did not close it, so its actual state
+  is whatever the code happens to be. Inspect before continuing.
+- `REVIEW` on entry means the code exists and nothing has verified it. Verify it before adding
+  more code on top.
+- `DONE` on entry is trusted only as far as its evidence. A `DONE` row whose evidence is a test
+  path is trustworthy once that test still passes; a `DONE` row with no evidence recorded is not
+  a `DONE` row — set it back to `REVIEW`.

--- a/kit/skills/core/hc-jest/SKILL.md
+++ b/kit/skills/core/hc-jest/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: hc-jest
+description: "Write Jest unit tests for JavaScript classes. Use this skill whenever the user asks to create or update Jest tests for a class."
+---
+
+# Jest Class Testing
+
+A skill for writing Jest unit tests for JavaScript classes.
+The conventions are split across the detail files below. Refer to them as needed.
+
+> **Notation convention**: Throughout this skill, when we simply write
+> `describe()` / `test()` / `expect()`, each is a **generic term that implies**
+> the corresponding `.each()` variant (`describe()` includes `describe.each()`,
+> `test()` includes `test.each()`, and `expect()` includes `expect.each()`).
+> Where the context is limited to one or the other specifically, that will be stated explicitly.
+>
+> Also, use `test()` / `test.each()` for test blocks and never `it()` / `it.each()`
+> (`it()` is easy to misread as `if()`; lint also enforces `test` via
+> `jest/consistent-test-it`; see [eslint-jest-rules.md](./references/eslint-jest-rules.md)).
+
+## Core principle: don't cut coverage using implementation knowledge (QA stance)
+
+Tests must be written so that they **notice even if the implementation is wrong**.
+Using knowledge gained from reading the implementation to judge "this will always
+be this value" or "this member is obvious" and then **omitting cases or members,
+or collapsing them into a single `test()`, is a QA mistake**. What a test must
+guarantee is not the implementation's internal circumstances, but the member's
+**contract (externally observable behavior) as a black box**.
+
+- Do not omit something because "the implementation is written this way so it's
+  fine." If you do, hard-coding or regressions can slip in without the test
+  noticing, which defeats the purpose of having a test at all.
+- Example: for the instance getter `get Ctor () { return this.constructor }`,
+  collapsing it into a single `test()` that says "in the base class it's always
+  `BoundCtorRegistry`" would still pass even for the hard-coded implementation
+  `return BoundCtorRegistry`. Only by running the variable element (the
+  instance's type) through `test.each()` can you verify the contract
+  ([structure.md](./references/structure.md#instance-getters-require-testeach-the-variable-element-is-the-instance)).
+- Example: don't skip testing a static property because "the memoization
+  pool is an implementation detail." Members that appear public should be
+  verified as part of the contract.
+- Example: for a member that **transforms a property/argument before using it**
+  (escape / normalize / encode, etc.), don't test only with values for which the
+  transformation is a no-op. Always include **a value that actually exercises the
+  transformation** so that a broken transformation would be noticed
+  ([test-cases.md](./references/test-cases.md#choose-values-that-exercise-the-internal-transformation-dont-fill-cases-with-no-op-values-only)).
+- When in doubt, err **on the side of coverage**. When trimming a member,
+  branch, or variable element, the justification must be "this input/state
+  cannot exist under the contract," never "because I know the implementation."
+
+## Core principle: don't put logic in test files
+
+A test must consist **only of assertions** (`expect()`) that **check simple
+input and output values**. Writing logic inside a test to prepare it is a
+well-known anti-pattern. Test code itself is not verified, so if raw logic
+written inside a test is wrong, nobody notices, and the reliability of the test
+collapses.
+
+- The only things allowed for use inside a test are things that **have already
+  been tested elsewhere and have guaranteed behavior** (already-tested classes,
+  factory methods, literal data, etc.). Do not write unverified transformations,
+  branches, or helper definitions.
+- Inside `describe()`, do not use `if` / ternary / `??` / short-circuit
+  evaluation / higher-order functions / `forEach`. Express repetition with
+  `expect.each()` from `@openreachtech/jest-expect-each`.
+- See [anti-pattern.md](./references/anti-pattern.md) for details and examples.
+
+## Core principle: index the first and second levels by definition name (class/member)
+
+The nesting of `describe()` is fixed as **level 1 = class name**,
+**level 2 = member name**. Do not write behavior (`should ...` / `when ...`)
+directly at levels 1 or 2. Behavior must always go at **level 3 or deeper**,
+following the order `describe(class) > describe(member) > describe(behavior) >
+test()`.
+
+- **Why**: One of the main purposes of a test is that **a human can later
+  look up the test for a given target**. When fixing a member in the
+  implementation, one must be able to reach the corresponding test with the
+  shortest path possible. Fixing levels 1 and 2 to definition names makes the
+  **implementation structure (class → member) directly the index key of the
+  tests**, so code and tests can be looked up one-to-one, in either direction.
+- A behavior-first style (BDD-leaning writing that starts with
+  `describe('should return 401 when ...')`) reads well as a specification, but
+  it is slow to look up "where is the test for `FooResolver#resolve()`."
+  Because the class → member correspondence has no syntactic anchor, finding
+  the corresponding test from the implementation requires grepping the whole
+  file or tree exploration. This skill prioritizes lowering this **search
+  cost** through syntax.
+- **Prevents duplicate tests**: if you cannot look up "where" the test for a
+  target member is, you cannot check whether an equivalent test already
+  exists, and **similar tests end up added redundantly**. This is especially
+  true **when multiple people work on the same codebase** — each person adds
+  tests without being able to find existing ones, which easily produces
+  duplication and coverage gaps. Indexing by definition name concentrates
+  "the test for this member is in exactly one place," letting you check
+  existing tests before adding new ones.
+- As a consequence of this policy, the class-name `describe()` is **repeated**
+  per member (one class `describe()` holds only one member). Even when
+  fast-scrolling a long file, the class name always sits directly above the
+  member `describe()`, so "which class, which member am I looking at" always
+  stays on screen (a syntactically achieved sticky header). We accept that the
+  class name is duplicated in Jest's output, in favor of human explorability.
+- For details on nesting structure and notation, see
+  [structure.md](./references/structure.md#describe-structure) /
+  [naming.md](./references/naming.md#notation-of-class-members).
+
+## Write comments in the code in English
+
+Comments written inside test code (`.js`) must be written in **English**. This
+unifies the comment language to English, aligning with other comments in the
+codebase.
+
+- This applies to **comments inside the test code generated under tests/**
+  (`// same reference` / `// neutral value; not under test` /
+  `// all omitted → default; keep last`, etc. — `//` or `/* */` written in
+  `.js` files). These are generated artifacts, hence English.
+- The prose in this skill's own documentation (the body text of each Markdown
+  file) remains in Japanese.
+- Comments inside **this skill's own examples** (` ```js ``` ` blocks) are
+  *explanations* of the skill, so they are written in the same **Japanese**
+  as the body text.
+
+## Detail files
+
+- [directory.md](./references/directory.md) — directory layout, import paths
+- [structure.md](./references/structure.md) — structure of describe / test
+- [test-cases.md](./references/test-cases.md) — data conventions for `cases`
+- [aaa-pattern.md](./references/aaa-pattern.md) — Arrange / Act / Assert
+- [mocks.md](./references/mocks.md) — mocks/stubs (inside Arrange, overridden with `jest.spyOn()`)
+- [naming.md](./references/naming.md) — naming of variables and case properties
+- [types.md](./references/types.md) — type annotations and type resolution
+- [anti-pattern.md](./references/anti-pattern.md) — don't put logic in tests (forbidden syntax, extracting helpers)
+- [prohibit.md](./references/prohibit.md) — prohibited items (forbidden matchers, etc.)
+- [eslint-jest-rules.md](./references/eslint-jest-rules.md) — ESLint (jest plugin) mapping (follow it and `npm run lint` passes; intentionally relaxed rules)

--- a/kit/skills/core/hc-jest/references/aaa-pattern.md
+++ b/kit/skills/core/hc-jest/references/aaa-pattern.md
@@ -1,0 +1,390 @@
+# AAA Pattern
+
+Convention for Arrange / Act / Assert in Jest. Referenced from `SKILL.md`.
+See [naming.md](./naming.md) for the naming of the variable that receives
+Act's return value (`received`). Insert a **blank line** between Arrange /
+Act / Assert to make the separation explicit.
+
+```js
+test.each(cases)('...', ({ input, expected }) => {
+  const builder = SomeClass.create(input) // Arrange
+
+  const received = builder.someMethod(input) // Act
+
+  expect(received) // Assert
+    .toBe(expected)
+})
+```
+
+## Pass a variable to `expect()` (not an expression)
+
+The **subject** passed to `expect()` should be **a variable**. Don't write a
+property access or expression directly, as in `expect(received.name)`.
+
+- If you're asserting on Act's return value itself, pass `received` as-is.
+- If you're asserting on **a property** of Act's return value, first receive
+  the return value with **a descriptively named variable** (for a class/
+  constructor, PascalCase like `DeclaredCtor`), then create `received` as
+  `const received = <var>.<prop>` and pass `received` to `expect(received)`.
+  This separates "the execution result" and "the value being asserted" as
+  variables.
+- Since the return value and the extraction are tightly coupled, don't put a
+  blank line between `const <Var> = ...` and
+  `const received = <Var>.<prop>`; put the blank line after them to separate
+  from Assert.
+
+```js
+// Good: receive Act's return value with a named variable, then create received before passing to expect
+const DeclaredCtor = registry.declareBoundCtor(args) // Act
+const received = DeclaredCtor.name
+
+expect(received) // Assert
+  .toBe(expected)
+```
+
+```js
+// Avoid: passing an expression (property access) directly to expect()
+const received = registry.declareBoundCtor(args)
+
+expect(received.name)
+  .toBe(expected)
+```
+
+## Assemble method arguments in Arrange, and pass a variable in Act
+
+Do not **assemble the argument object of the method under test (Act) inline
+in the call**. Building the argument is noise relative to the call logic, so
+define it in Arrange as `const args = { ... }`, and pass that variable in
+Act. Only when building args happens **multiple times** within a single test
+(e.g. one for the constructor and one for a method) do you split it by the
+target member name + `Args` instead of `args`
+([naming.md](./naming.md#naming-the-args-object)).
+
+- This applies when you're "assembling an object on the spot and passing it"
+  (`method({ value: {} })`, `method({ value: input.value })`, shorthand
+  `method({ valueHash })`, etc.).
+- If you're just passing a value that's already a variable, as-is
+  (`method(input)`), there's no assembly, so it's fine to inline it.
+- Both building `args` and creating the test-target instance are Arrange, so
+  do not separate them with a blank line ([Use blank lines only to separate
+  the three phases](#use-blank-lines-only-to-separate-the-three-phases)).
+- If **`args` is case-invariant** (it doesn't depend on `input` / `expected`
+  received by the `test.each()` callback, and can be built from fixed
+  fixtures alone), don't rebuild it every time inside the callback — define
+  it **once, outside `test.each()`**. Only build arguments that depend on
+  the case's value inside the callback (the same principle is detailed in
+  [structure.md's placement rules](./structure.md#placement-within-a-describeeach-callback-what-may-go-before-testeach)).
+
+```js
+// Good: args is case-invariant (deriver is fixed) → defined once outside test.each()
+describe('should be named after base constructor', () => {
+  /**
+   * @param {{ Ctor: new () => * }} params
+   * @returns {new () => *}
+   */
+  const deriver = ({ Ctor }) => class extends Ctor {}
+
+  const args = {
+    deriver,
+  }
+
+  const cases = [ /* ... */ ]
+
+  test.each(cases)('BaseCtor: $input.BaseCtor.name', ({ input, expected }) => {
+    const registry = new BoundCtorRegistry(input) // depends on input, so it's inside the callback
+
+    const DeclaredCtor = registry.declareBoundCtor(args)
+    const received = DeclaredCtor.name
+
+    expect(received)
+      .toBe(expected)
+  })
+})
+```
+
+```js
+// Good: assemble the argument in Arrange, and pass args in Act
+test.each(cases)('value: $input.value', ({ input, expected }) => {
+  const stringifier = new JsonRequestBodyStringifier({
+    replacer: input.replacer,
+  })
+  const args = {
+    value: input.value,
+  }
+
+  const received = stringifier.stringifyBody(args)
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+```js
+// Avoid: writing the argument object inline into the call (assembly logic leaks into Act)
+test.each(cases)('value: $input.value', ({ input, expected }) => {
+  const stringifier = new JsonRequestBodyStringifier({
+    replacer: input.replacer,
+  })
+
+  const received = stringifier.stringifyBody({
+    value: input.value,
+  })
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+## Only `expected` and `tally` may be passed to the matcher
+
+Only **`expected`** and **`tally`** may be passed to Assert's matcher
+(`toBe()` / `toHaveBeenCalledWith()`, etc.). **`input`** (or `override`),
+which was used in Arrange to drive the call, **must not be passed to the
+matcher**. This is to keep "the value passed in" and "the value expected"
+separate even in the code.
+
+- `expected`: the expected value. Use it when you want it kept separate from
+  the value passed in (post-transformation, a different shape, a different
+  thing).
+- `tally`: a value used for a full comparison when the value passed in and
+  the expected value are **identical**. Pass the **same** `tally` to
+  **both** the call and the matcher ([naming.md](./naming.md)'s `tally`
+  entry). `tally` may have multiple named members, and if each member is
+  passed and asserted **as-is**, use the whole reference `tally.alpha` too
+  (not partial use). If it's wrapped or only part of it is extracted before
+  passing, use `input` instead.
+
+- When the matcher takes **multiple arguments** (like
+  `toHaveBeenCalledWith(a, b)`), make `expected` **an array of the
+  arguments** and spread it with `...expected`. Spreading an array that
+  represents the whole argument list corresponds 1:1 with the matcher's
+  argument structure and reads better than destructuring into properties
+  like `expected.a` / `expected.b`.
+- When verifying multiple calls, make `expected` **an array of per-call
+  argument arrays**, and spread each call as `...expected[0]` /
+  `...expected[1]`, etc.
+
+```js
+const cases = [
+  {
+    input: {
+      value: { id: 100001 },
+      replacer: alphaReplacer,
+    },
+    expected: [
+      { id: 100001 },
+      alphaReplacer,
+    ],
+  },
+]
+
+test.each(cases)('value: $input.value', ({ input, expected }) => {
+  const stringifySpy = jest.spyOn(JSON, 'stringify')
+
+  const stringifier = new JsonRequestBodyStringifier({
+    replacer: input.replacer,
+  })
+  const args = {
+    value: input.value,
+  }
+
+  stringifier.stringifyBody(args)
+
+  expect(stringifySpy)
+    .toHaveBeenCalledWith(...expected) // spread expected, not input
+})
+```
+
+## Write expected-value literals inline if single-line, bind to `const expected` if multi-line
+
+When writing an expected value **as a literal in the test body** (a single
+`test()` that doesn't use `cases` — a fixed value for `when called as is`,
+inheritance, a fixed message for `when not inherited`, etc.), decide whether
+to write it directly in the matcher or bind it to `const expected` based on
+**whether the value is single-line or multi-line**. In `test.each()`,
+`expected` is always a variable destructured from `cases`, so this
+distinction only matters for a single `test()` that writes a literal in the body.
+
+| Expected-value literal | How to write it |
+| :-- | :-- |
+| **Single-line** (`'...'` / number / boolean / `{ id: 100001 }` / `[Alpha, Beta]`) | Write **directly** in the matcher (`toBe(...)` / `toEqual(...)`) |
+| **Multi-line** (a multi-key object, nested, an array of objects) | **Bind** to `const expected`, keep the matcher line as `.toEqual(expected)` |
+
+- The deciding axis is not "is it a primitive or not" but "**can the matcher
+  line fit in a short single token, or does it become a multi-line block**."
+  Primitives are always single-line, so they fall into the direct-write case
+  (as one instance of this).
+- "Single-line vs. multi-line" is not an arbitrary threshold — it is
+  **already determined** by the formatting convention in
+  [test-cases.md](./test-cases.md#at-most-one-property-key-per-line) (single-key
+  leaves may be inline, multi-key must be expanded, structural containers
+  must be broken onto new lines). An object with multiple keys or more is
+  always multi-line, so it falls into the bound-variable case.
+- **Why multi-line is bound**: writing a multi-line literal directly into
+  `.toEqual({ ... })` mixes the matcher's `)` with the object's `}`, erasing the
+  outline of the Assert phase ([Use blank lines only to separate the three
+  phases](#use-blank-lines-only-to-separate-the-three-phases)). Escaping it into
+  `const expected` keeps the matcher line contained as `.toEqual(expected)`, which also
+  aligns with the spirit of [Pass a variable to
+  `expect()`](#pass-a-variable-to-expect-not-an-expression). The bound `const expected`
+  belongs to the Arrange phase, so separate it from Act (`received`) with a blank line.
+- **A literal `const expected` binding is different from binding a runtime-generated value**. A
+  multi-line object literal (`const expected = { ... }`) is instantly recognizable as static, and is
+  distinguishable at the binding point from a memoized `const expected = someCall()`
+  ([structure.md](./structure.md#methods-that-memoize-and-return-the-same-reference-should-be-memoized)),
+  so the meaning of `const expected` doesn't get confused.
+- **When the expected value can't be compared as a literal** (`WeakMap` /
+  `Set` / a memoized instance, etc. — something whose reference is unique and
+  opaque), this falls back, before this branch, to `toBeInstanceOf(<type>)` or
+  same-reference `toBe(expected)`
+  ([structure.md](./structure.md#if-the-fixed-value-is-an-object-pin-it-by-type-tobeinstanceof)).
+
+```js
+// Single-line → write directly in the matcher
+test('should be fixed value', () => {
+  const received = CreateBenchmarkProjectMutationResolver.schema
+
+  expect(received)
+    .toBe('createBenchmarkProject')
+})
+```
+
+```js
+// Multi-line → bind to const expected, keep the matcher line as .toEqual(expected)
+test('should be fixed value', () => {
+  const expected = {
+    type: 'object',
+    required: [
+      'id',
+    ],
+  }
+
+  const received = SomeResolver.schema
+
+  expect(received)
+    .toEqual(expected)
+})
+```
+
+## Add `// same reference` to a `toBe()` that checks the same reference
+
+When passing an object (a function, instance, array, etc. — a non-primitive
+value) to `toBe()` to verify **the same reference**, add a
+`// same reference` comment at the end of the assertion line. Since `toBe()`
+uses `Object.is` comparison, this makes explicit that the intent is checking
+"is it the same reference," not primitive value equality.
+
+- This applies only when passing an object reference. Don't add the comment
+  for primitive value equality (strings, numbers, etc.), such as
+  `toBe('Basic')`.
+
+```js
+test('should be fixed value', () => {
+  const received = BasicAuthorizationBuilder.btoa
+
+  expect(received)
+    .toBe(btoa) // same reference
+})
+```
+
+## Use blank lines only to separate the three phases
+
+**Blank lines should only be used to separate the three phases** of
+Arrange / Act / Assert. Even if a single phase has multiple steps, **do not
+separate its interior** with blank lines. This makes it possible to tell
+unambiguously "where the phase changes" from the presence of a blank line.
+
+- Keep multiple lines within one phase close together, and leave a blank
+  line only at the phase boundary.
+- For example, if you split Arrange into two steps — "build the argument
+  object" and "create the instance" — **don't put a blank line between
+  them**, since both belong to the same Arrange.
+
+```js
+test.each(cases)('...', ({ input, expected }) => {
+  const args = { // Arrange (logic (1): building the argument object)
+    scheme: input.scheme,
+    credential,
+  }
+  const builder = new BaseAuthorizationBuilder(args) // Arrange (logic (2): creating the instance)
+
+  const received = builder.generateHeaderValue() // Act
+
+  expect(received) // Assert
+    .toBe(expected)
+})
+```
+
+A wrong example (splitting one tightly-coupled piece of logic with a blank
+line within the same Arrange):
+
+```js
+test.each(cases)('...', ({ input, expected }) => {
+  const args = {
+    scheme: input.scheme,
+    credential,
+  }
+
+  const builder = new BaseAuthorizationBuilder(args) // ← don't add a blank line here, since this preparation is tightly coupled to creating the instance
+
+  const received = builder.generateHeaderValue()
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+### However, groups of statements with different meanings should be separated by blank lines
+
+Even within the same Arrange, if **groups of statements with different
+purposes (meanings)** appear side by side, it is fine to separate the groups
+with a blank line. This is not as strong as the phase boundary (A/A/A), but
+visually separating "distinct concerns within the preparation" improves
+readability.
+
+- Steps that are **tightly coupled toward a single result**, like "build the
+  argument → create with that argument," should not be separated (as above).
+- Groups with **separate concerns**, like "setting up mocks" and "creating a
+  spy," should be separated by a blank line.
+- **Creating the subject** (the test-target instance) and **the group of
+  argument preparation** (defining `args` + its `jest.spyOn(args, key)`,
+  etc.) are also separate concerns. **Create the subject first**, then place
+  the argument-preparation group after a blank line. Since `args` and the
+  `spyOn` applied to it are tightly coupled, don't separate the interior of
+  that group ([mocks.md](./mocks.md#verifying-calls-to-a-function-passed-as-an-argument-callback--handler--deriver-with-jestspyonargs-key)).
+
+```js
+test.each(cases)('source: $input.source', ({ override, input, expected }) => {
+  jest.spyOn(BaseAuthorizationBuilder, 'schema', 'get') // Arrange (concern 1: stub the return value)
+    .mockReturnValue(override.schema)
+  jest.spyOn(BaseAuthorizationBuilder, 'generateCredential')
+    .mockReturnValue(override.credential)
+
+  const SpyClass = constructorSpy.spyOn(BaseAuthorizationBuilder) // Arrange (concern 2: create the spy)
+
+  SpyClass.create(input) // Act
+
+  expect(SpyClass.__spy__) // Assert
+    .toHaveBeenCalledWith(expected)
+})
+```
+
+```js
+test.each(cases)('BaseCtor: $input.BaseCtor.name', ({ input, expected }) => {
+  const registry = new BoundCtorRegistry(input) // Arrange (concern 1: subject)
+
+  const args = { // Arrange (concern 2: argument preparation; the args definition and its spyOn are tightly coupled, so don't separate the interior)
+    /**
+     * @param {{ Ctor: new () => * }} params
+     * @returns {new () => *}
+     */
+    deriver: ({ Ctor }) => class extends Ctor {},
+  }
+  const deriverSpy = jest.spyOn(args, 'deriver')
+
+  registry.declareBoundCtor(args) // Act
+
+  expect(deriverSpy) // Assert
+    .toHaveBeenCalledWith(expected)
+})
+```

--- a/kit/skills/core/hc-jest/references/anti-pattern.md
+++ b/kit/skills/core/hc-jest/references/anti-pattern.md
@@ -1,0 +1,200 @@
+# Anti-pattern (Do Not Write Logic in Test Files)
+
+Conventions for "syntax that may be written in test code" vs. "syntax that must
+not be written" in jest. Referenced from `SKILL.md`.
+
+## Core Principle: Do Not Write Logic in Test Files
+
+A test should consist **solely of assertions** (`expect()` in Jest) that check
+simple input and output values. Writing logic to prepare a test inside the test
+itself is a well-known testing anti-pattern. Since the test code itself is not
+verified, if raw logic written inside the test is wrong, nobody will notice, and
+the reliability of the test collapses.
+
+- What a test should verify is "the contract of the member under test," not the
+  correctness of preparation logic assembled within the test (this shares the
+  same root as the QA stance in [SKILL.md](../SKILL.md)).
+- If preparation is needed (e.g. DB seeding), don't write logic inside the test
+  — delegate it to an **external mechanism** (a seeder / an already-tested
+  tool).
+
+### Example: Preparation Logic Without a Seeder Produces False Positives
+
+If you write a "document deletion" test without using a seeder, you tend to end
+up with a procedure like this:
+
+1. Insert the target within the test.
+2. Delete the target within the test.
+3. Confirm the target does not exist in the DB table (test passes).
+
+This is clearly bad. **Even if the insert did nothing** (the table never
+changed), and **even if the delete did nothing**, step 3's "does not exist"
+check will still pass. To work around this you'd have to add an extra
+`expect()` between steps 1 and 2 to confirm the DB actually changed — but
+**deleting the document itself is not the purpose of this test**. The correct
+approach is to delegate preparation to a seeder and not bring preparation logic
+into the test.
+
+## Only Logic That Is "Verified by a Test" May Be Used
+
+The criterion for whether logic may be used inside a test is: **is that logic
+itself tested elsewhere, with its behavior guaranteed?**
+
+```js
+// ❌️ Writing untested transformation logic inside the test
+array.map(it => it.id)
+
+// ✅️ Using an already-tested class (behavior is guaranteed)
+SampleClass.create(...)
+```
+
+- ❌️ The transformation `array.map(it => it.id)` is not tested anywhere. If it
+  is wrong, nobody will notice.
+- ✅️ `SampleClass` has its own separate tests written, so it may be used freely
+  inside a test.
+
+### What May Be Used Freely
+
+- **Data expressible as literals** (object/array literals, etc.).
+- **Tested factory methods** (e.g. a `create()` that instantiates another
+  class).
+- **Tested helper functions** (ones extracted into `tests/tools/`, described
+  below).
+
+## Do Not Define Helper Functions Inside a Test File (Violation of File Responsibility)
+
+Do not define helper functions inside a test file. Function definitions like
+the following also count as "logic."
+
+```js
+// ❌️ Defining a helper function inside the test file
+function createSamples ({ options }) {
+  return new Sample(options)
+}
+```
+
+- If **no test exists** to confirm the correctness of that function, this
+  amounts to using untested logic in a test — not allowed.
+- Even **if a test is written, but it lives in the same file** — that is **a
+  violation of file responsibility**. A test file's **class name is its file
+  name** (`Sample.js` tests the `Sample` class), and its responsibility is
+  limited to "testing that class." Writing "a test for a test tool (helper
+  function)" inside it clearly mixes responsibilities.
+
+### If a Helper Function Is Truly Necessary
+
+1. **Define** the helper function under `tests/tools/`.
+2. **Write tests** for the helper function under `tests/__tests__/test-tools/`,
+   **mirroring the directory structure** of `tests/tools/` (the same mirroring
+   concept as [directory.md](./directory.md)).
+3. Once a helper function has tests this way, it becomes a **tested helper
+   function** that may be used freely inside test files.
+
+## Prohibited Syntax
+
+Since a test consists solely of input/output assertions, do not write control
+flow, conditional branching, or unverified transformations inside `describe()`.
+Specifically, the following are **prohibited**:
+
+- `if` statements
+- The ternary operator (`? :`)
+- The nullish coalescing operator (`??`)
+- Short-circuit evaluation (`||` / `&&`)
+- **Higher-order functions** (`Array#map()` / `filter()` / `reduce()`, etc.). The
+  moment the argument passed is a **function**, unverified logic can occur
+  inside it.
+- `Array#forEach()`. ESLint conditionally allows this ("permitted as long as no
+  assignment statement is written inside"), but it is **prohibited within test
+  files** (iteration should instead be expressed with `expect.each()`, described
+  below).
+
+### What Does Not Count as Logic
+
+Code that **references a variable already defined within `describe()` to
+construct a new object** is not judged to be logic. Assembling an `args` or a
+`cases` element object by referencing a fixture variable is permitted to that
+extent (what is prohibited is unverified transformation, branching, and helper
+definitions).
+
+```js
+// OK: merely constructs an object by referencing a variable defined within describe()
+const args = {
+  scheme: input.scheme,
+  credential,
+}
+```
+
+## Do Not Apply DRY to Test Code (Define Things Inside Each `describe()`)
+
+**The DRY principle generally does not apply to test code.** Even if the same
+value or definition is needed in multiple places, do not consolidate it and
+hoist it to file scope (outside all `describe()` blocks). This applies **not
+only to assignment statements (variable definitions) but also to class
+definitions, function definitions, and so on** — define each of these
+**separately inside each `describe()`** that uses it. The **only** thing that
+may live at file scope is **imports**.
+
+- **Why DRY does not apply**: When you need to change the value of a shared
+  definition, you must **consider the assumptions of every `describe()` that
+  depends on it**. For example, if you want to change the value for just one
+  method, you can't touch the shared definition, so you end up
+  **copy-pasting and modifying it** inside that specific `describe()` anyway. If
+  that's how it ends up, **it's correct to define it individually from the
+  start**.
+- Shared state at file scope is also hard to trace back to which
+  `describe()` / `test()` depends on it, creating implicit coupling and
+  contamination between tests. Confining it inside each `describe()` lets you
+  read that block alone and have the assumptions be self-contained (this also
+  aligns with the sticky-header policy of repeating the class-name describe per
+  member;
+  [structure.md](./structure.md#do-not-define-shared-variables-outside-describe-at-file-scope)).
+- Even if generation cost is a concern (e.g. building a derived class via a
+  factory), it's fine to define it each time (tests prioritize correctness and
+  independence).
+
+```js
+// ❌️ Defined at file scope and reused across multiple describe() blocks (applying DRY)
+const minValue = 10
+
+describe('SampleClass', () => {
+  describe('#calculateAverage()', () => {
+    // use minValue here
+  })
+})
+
+describe('SampleClass', () => {
+  describe('#calculateTotal()', () => {
+    // use minValue here too
+  })
+})
+```
+
+```js
+// ✅️ Define it separately inside each describe() that uses it
+describe('SampleClass', () => {
+  describe('#calculateAverage()', () => {
+    const minValue = 10
+    // use minValue here
+  })
+})
+
+describe('SampleClass', () => {
+  describe('#calculateTotal()', () => {
+    const minValue = 10
+    // use minValue here
+  })
+})
+```
+
+## Use `expect.each()` for Iteration (Replacement for `forEach`)
+
+Instead of `Array#forEach()`, use the Jest extension defined by
+`@openreachtech/jest-expect-each` for iteration.
+
+- `expect.each().toXxxx()`
+- `expect.each().toXxxx.each()`
+
+`toXxxx` refers to a **standard Jest matcher** (`toBe()` / `toEqual()` /
+`toThrow()`, etc.). `expect.each()` is an extension, provided by
+`@openreachtech/jest-expect-each`, that lets you apply that standard matcher
+repeatedly across multiple values.

--- a/kit/skills/core/hc-jest/references/directory.md
+++ b/kit/skills/core/hc-jest/references/directory.md
@@ -1,0 +1,154 @@
+# Directory (Directory Structure and Imports)
+
+Conventions for where test files are placed and how import paths are written in
+jest. Referenced from `SKILL.md`.
+
+## Why We Don't Co-locate (Reasons for Isolating Tests in a Dedicated Tree)
+
+Tests do not use **co-location** (placing `Foo.test.js` next to `Foo.js` in the
+same directory as the source); instead they are isolated in a **dedicated
+`tests/` tree** (placement details are below in
+[Directory Structure](#directory-structure)). The answer to "why not
+co-location" comes down to four points, all of which share the same root:
+**with a directory boundary, you can state "everything inside the boundary is X"
+as a positive allowlist, but co-location forces you to state "everything,
+except tests" as a negative denylist everywhere** — and a denylist is always a
+source of bugs from **falling out of sync with test naming conventions**.
+
+Note that test discoverability (where the tests for a given member live) is
+guaranteed by the describe syntax (the core principle in [SKILL.md](../SKILL.md),
+"index the 1st and 2nd levels by definition name"). Since discovery does not
+rely on placement, placement can be chosen freely, letting us capture the
+benefits listed below.
+
+1. **Configuration can be strongly scoped per directory.**
+   ESLint overrides / tsconfig / jest environment / coverage targets, etc. can
+   all be applied **wholesale** to `tests/**`. You can guarantee "loosen or
+   tighten rules for tests only" by **location**, without relying on file-name
+   glob discipline (`*.test.js`). With co-location, you end up relying on globs,
+   and suffix inconsistencies let rules **slip through or misfire on production
+   code**.
+
+2. **It doesn't pollute loaders that walk a directory (directory-as-registry).**
+   Many implementations, like a `DeepCtorsLoader` that loads every class under
+   `server/resolvers/`, **use the folder itself as a registry (declaration)**.
+   Co-location degrades the contract "everything under here = every resolver"
+   into "everything under here, **except tests**," forcing the
+   **production/runtime loader to carry exclusion logic** (a layering
+   violation). Any gap in that filter becomes a production bug where a test
+   file gets **loaded as a resolver at runtime**. With a dedicated tree, the
+   implementation folder stays pure, and the loader can walk it
+   **unconditionally**.
+
+3. **npm publish can be handled with a simple allowlist.**
+   If `lib/` is pure, the publish spec is a one-liner: `"files": ["lib"]`. With
+   co-location, you either publish the tests along with everything else,
+   **polluting the package** (bloated installs, broken references to
+   devDependencies, information leaks via fixtures), or you're stuck
+   **endlessly maintaining exclusions** in `.npmignore` (e.g.
+   `**/*.test.js`) — and any gap leaks tests into the production package.
+
+4. **It complements a build that skips compilation.** This package **publishes
+   `lib/*.js` as-is** (ESM, no build; types are checked only via JSDoc +
+   `tsc --noEmit`). This gives real benefits: no build toolchain needed, faster
+   CI, and "what you debug is what you ship" (no source maps needed, stack
+   traces point to real file lines). At the same time, this setup has **no emit
+   step** (the filter a TS compile configuration would use to filter `.test.ts`
+   out of build artifacts). A dedicated tree keeps `lib/` pure from the start,
+   which is **consistent** with the absence of that filter. Co-location combined
+   with no-compile is the **worst combination** — tests sit in `lib/` with no
+   filtering boundary at all, forcing you to manually fill in all of the
+   denylists from points 2 and 3 above.
+
+## Directory Structure
+
+The location of tests mirrors the directory structure under the source's
+`lib/` directly under `tests/__tests__/`.
+
+- `lib/` is the mirroring base point. Do not include `lib/` in the test-side
+  path.
+- Place the remaining path, with `lib/` stripped off, directly under
+  `tests/__tests__/`.
+
+Example:
+
+| Source | Test |
+| --- | --- |
+| `lib/tools/PathnameBuilder.js` | `tests/__tests__/tools/PathnameBuilder.js` |
+| `lib/Foo.js` | `tests/__tests__/Foo.js` |
+| `lib/a/b/Bar.js` | `tests/__tests__/a/b/Bar.js` |
+
+Incorrect example: `tests/__tests__/lib/tools/PathnameBuilder.js`
+(must not include `lib/`)
+
+## Splitting Large Test Files
+
+If a single test file grows too large, it may be **split by method**. In that
+case, use **the class name as a directory** and place per-method files
+underneath it.
+
+- Before splitting: `tests/__tests__/tools/PathnameBuilder.js`
+- After splitting: turn the class name `PathnameBuilder` into a directory.
+
+```
+tests/__tests__/tools/PathnameBuilder/
+  constructor.js
+  create.js
+  buildPathname.js
+```
+
+- Directory mirroring (not including `lib/`, etc.) stays the same after
+  splitting: `lib/tools/PathnameBuilder.js` ↔
+  `tests/__tests__/tools/PathnameBuilder/`.
+- Splitting is a remedy for bloat and is not mandatory. A single file is fine
+  while it stays small.
+
+## Test Tools (Where to Place Helper Functions)
+
+Do not define helper functions inside a test file
+([anti-pattern.md](./anti-pattern.md)). If one is truly necessary, **define** it
+under `tests/tools/`, and **mirror the same directory structure** under
+`tests/__tests__/test-tools/` to **write tests** for the helper function.
+
+- The mirroring base point, not including `lib/`, etc., follows the same idea
+  as the Directory Structure section above:
+  `tests/tools/foo/makeSample.js` ↔ `tests/__tests__/test-tools/foo/makeSample.js`.
+- Only helper functions that have tests written for them may be used inside
+  test files.
+
+## Import Path
+
+Import the subject under test using a **relative path**, not an alias like `~`.
+The relative path traces the directory structure directly.
+
+```js
+// Correct (from tests/__tests__/tools/PathnameBuilder.js)
+import PathnameBuilder from '../../../lib/tools/PathnameBuilder.js'
+
+// Incorrect
+import PathnameBuilder from '~/lib/tools/PathnameBuilder.js'
+```
+
+## Import Order
+
+Among classes imported from this package (`lib/`), write **the subject under
+test first**. Separate subsequent imports (base classes, etc.) from the subject
+import with a **blank line**.
+
+- Placing the subject under test first makes "what this file tests" clear from
+  the very first line.
+- Subsequent imports (base classes, collaborator classes, etc.) are grouped
+  together after the blank line.
+
+```js
+// Correct (testing a subclass: subject first, base class separated by a blank line)
+import BasicAuthorizationBuilder from '../../../../../lib/request/authorization-builder/concretes/BasicAuthorizationBuilder.js'
+
+import BaseAuthorizationBuilder from '../../../../../lib/request/authorization-builder/BaseAuthorizationBuilder.js'
+```
+
+```js
+// Incorrect (subject and base class listed with no blank line between them)
+import BasicAuthorizationBuilder from '.../concretes/BasicAuthorizationBuilder.js'
+import BaseAuthorizationBuilder from '.../BaseAuthorizationBuilder.js'
+```

--- a/kit/skills/core/hc-jest/references/eslint-jest-rules.md
+++ b/kit/skills/core/hc-jest/references/eslint-jest-rules.md
@@ -1,0 +1,163 @@
+# ESLint (jest plugin) mapping
+
+This maps the jest rules **actually in effect** under this project's ESLint
+configuration (`eslint-plugin-jest`'s `flat/recommended` plus overrides, bundled
+by `@openreachtech/eslint-config`) to how this skill writes tests. **If you write
+tests as this skill prescribes, `npm run lint` produces no jest-related errors.**
+Items that overlap with conventions in other files reinforce one another.
+
+> For the actual settings, see `eslint.config.js` (including the `tests/**/*.js`
+> overrides) and `configurations/plugins/jest.js` in `@openreachtech/eslint-config`.
+
+## Must follow (rules that error)
+
+- **Use `test()` / `test.each()`, never `it()` / `it.each()`** (both at top level and inside `describe()`). For
+  the reason, see the notation convention in [SKILL.md](../SKILL.md) (`it()` is
+  easy to misread as `if()`). — `jest/consistent-test-it`
+  (`fn: 'test'` / `withinDescribe: 'test'`)
+- **Each `test()` has at least one `expect()` / `expect()` only inside `test()` /
+  exactly one argument**. Wrapping assertions in a custom helper defeats detection
+  and errors. — `jest/expect-expect` / `jest/no-standalone-expect` /
+  `jest/valid-expect`
+- **Do not write `test.skip` / `test.only` / `xtest` / `ftest` / `xdescribe` /
+  `fdescribe`.** — `jest/no-disabled-tests` / `jest/no-focused-tests` /
+  `jest/no-test-prefixes`
+- **Do not leave commented-out tests.** — `jest/no-commented-out-tests`
+- **Do not write conditionals (`if` / `switch` / ternary / `&&` / `??`) inside a
+  `test()`, and do not place `expect()` under a conditional.** —
+  `jest/no-conditional-in-test` / `jest/no-conditional-expect` (same as
+  [anti-pattern.md](./anti-pattern.md))
+- **Iterate with `.each`, not loops** (`test.each()` / `describe.each()` /
+  `expect.each()`). — `jest/prefer-each`
+- **Do not end a `describe()` / `test()` title with `.`.** — `jest/valid-title`
+  (`mustNotMatch: '\\.$'`; consistent with shared/statements' no-trailing-period rule)
+- **Use `async` / `await`, not a `done` callback.** — `jest/no-done-callback`
+- **Do not `return` from a `test()` / do not `export` from a test file.** —
+  `jest/no-test-return-statement` / `jest/no-export`
+- **Hooks are only `beforeAll` / `beforeEach` / `afterAll` / `afterEach`, ordered
+  before→after, no duplicates, placed at the top of `describe()`.** —
+  `jest/prefer-hooks-in-order` / `jest/prefer-hooks-on-top` / `jest/no-duplicate-hooks`
+- **Do not use jasmine globals (`spyOn` / `fail` / `jasmine.*`) or import
+  `__mocks__`.** — `jest/no-jasmine-globals` / `jest/no-mocks-import`
+
+## How to choose matchers (follow these; otherwise they error)
+
+- **No alias matchers** (`toBeCalled` → `toHaveBeenCalled`, `toThrowError` →
+  `toThrow`, etc.). — `jest/no-alias-methods`
+- **Do not build comparisons/equality as expressions**: `expect(a === b).toBe(true)`
+  → `expect(a).toBe(b)` (`jest/prefer-equality-matcher`); `expect(a > b).toBe(true)`
+  → `expect(a).toBeGreaterThan(b)` (`jest/prefer-comparison-matcher`).
+- **Use `toBe()` for primitive equality.** — `jest/prefer-to-be`
+- **Use `toHaveLength()` for length** (`expect(arr.length).toBe(n)` is not allowed).
+  — `jest/prefer-to-have-length` (consistent with shared/statements' "do not
+  reference arrays individually via `[]` / `.length`")
+- **Use `toContain()` for containment.** — `jest/prefer-to-contain`
+- **Pass a message argument to `toThrow()`** (a bare `toThrow()` is not allowed). —
+  `jest/require-to-throw-message`
+- **Mock functions via `jest.spyOn()`, not a bare `jest.fn()`.** —
+  `jest/prefer-spy-on` (details in [prohibit.md](./prohibit.md) / [mocks.md](./mocks.md))
+- **Mock promises with `mockResolvedValue()` / `mockRejectedValue()`**
+  (`mockImplementation(() => Promise.resolve())` is not allowed). —
+  `jest/prefer-mock-promise-shorthand`
+- **`jest.mock()` factories must be typed** (this skill prefers `jest.spyOn()`, so
+  this rarely comes up). — `jest/no-untyped-mock-factory`
+
+### Verifying calls (count and arguments)
+
+- **Pin arguments whenever possible (`toHaveBeenCalledWith(...)`)**. Do not settle
+  for just "was it called" (`toHaveBeenCalled()`). — `jest/prefer-called-with`
+- **`toHaveBeenCalledTimes(n)` (count verification) may be used only when argument
+  verification is present alongside it.** To verify the count, line up
+  `toHaveBeenNthCalledWith(1, ...)` … `toHaveBeenNthCalledWith(n, ...)` n times,
+  pinning the arguments of every call. Verifying only the count lets arguments pass
+  through (QA stance; a convention of this skill, not lint-enforced).
+- **Split count patterns into a `describe()` per count** (`when called once` /
+  `when called twice` / `when called three times`, and if needed `when not called`
+  (= 0 times)). Within each `describe()` you can write `expect()` out flat, without
+  bringing in loops or conditionals (consistent with
+  [anti-pattern.md](./anti-pattern.md) / [structure.md](./structure.md)).
+
+```js
+describe('#notify()', () => {
+  describe('when called once', () => {
+    const cases = [
+      {
+        input: { events: ['alpha'] },
+        expected: { first: 'alpha' },
+      },
+    ]
+
+    test.each(cases)('events: $input.events', ({ input, expected }) => {
+      // arrange / act ...
+
+      expect(handlerSpy)
+        .toHaveBeenCalledTimes(1)
+      expect(handlerSpy)
+        .toHaveBeenNthCalledWith(1, expected.first)
+    })
+  })
+
+  describe('when called twice', () => {
+    const cases = [
+      {
+        input: { events: ['alpha', 'beta'] },
+        expected: { first: 'alpha', second: 'beta' },
+      },
+    ]
+
+    test.each(cases)('events: $input.events', ({ input, expected }) => {
+      // arrange / act ...
+
+      expect(handlerSpy)
+        .toHaveBeenCalledTimes(2)
+      expect(handlerSpy)
+        .toHaveBeenNthCalledWith(1, expected.first)
+      expect(handlerSpy)
+        .toHaveBeenNthCalledWith(2, expected.second)
+    })
+  })
+
+  describe('when not called', () => {
+    const cases = [
+      {
+        input: { events: [] },
+      },
+    ]
+
+    test.each(cases)('events: $input.events', ({ input }) => {
+      // arrange / act ...
+
+      expect(handlerSpy)
+        .not
+        .toHaveBeenCalled()
+    })
+  })
+})
+```
+
+## Snapshots
+
+- Inline snapshots up to 6 lines, external snapshots up to 12 lines. —
+  `jest/no-large-snapshots`
+- This skill pins concrete values with `toBe()` / `toEqual()`, so it does not use
+  snapshots in principle (same spirit as "do not use loose matchers" in
+  [prohibit.md](./prohibit.md)).
+
+## Intentionally relaxed rules (this skill's patterns rely on these)
+
+These are errors under `flat/recommended` but are turned **off** in this project.
+This skill's patterns pass lint precisely because they are off.
+
+- **`jest/no-identical-title` = off** → the **sticky-header approach of repeating
+  the class-name `describe()` per member** ("index the 1st/2nd levels by definition
+  name" in [SKILL.md](../SKILL.md)) passes lint. If it were on, identical titles
+  would error.
+- **`jest/prefer-lowercase-title` = off** (`ignoreTopLevelDescribe: true`) →
+  capitalized titles such as `describe('ClassName')` are allowed.
+- **`jest/prefer-strict-equal` = off** → `toEqual()` may be used (`toStrictEqual()`
+  is not forced).
+- **`require-top-level-describe` / `require-hook` / `no-hooks` (all hooks allowed) /
+  `max-expects` / `prefer-expect-assertions` = off**.
+- Under `tests/**/*.js`, `no-undefined` / `max-classes-per-file` / the no-static-class
+  `no-restricted-syntax` selector are **off** (test code may write `undefined`
+  literally, define multiple classes per file, and have classes without properties).

--- a/kit/skills/core/hc-jest/references/mocks.md
+++ b/kit/skills/core/hc-jest/references/mocks.md
@@ -1,0 +1,243 @@
+# Mocks (How to Supply Mocks and Stubs)
+
+Conventions for mocks and stubs in jest. Referenced from `SKILL.md`.
+See [naming.md](./naming.md) for the meaning of the `override` case property.
+
+## Override with jest.spyOn() Instead of Defining a Derived Class
+
+When you need a stub implementation of an abstract method, or need to swap out
+a method's return value, **avoid defining a new derived class whenever
+possible** and instead override (swap the return value of) a member on the
+subject class itself using `jest.spyOn()`.
+
+- For a getter: `jest.spyOn(TargetClass, '<name>', 'get').mockReturnValue(...)`.
+- For a method: `jest.spyOn(TargetClass, '<method>').mockReturnValue(...)`
+  (use `.mockImplementation(...)` if the return value needs to vary based on the
+  call arguments).
+- Keep the value being substituted in the `cases`' `override` property (per the
+  purpose of `override` described in [naming.md](./naming.md): supplementing an
+  abstract method with a stub implementation).
+- Tests should run and verify **the subject class itself**, not a derived class
+  (e.g. `toBeInstanceOf(TargetClass)`).
+- Mocks are restored automatically after every test via
+  `afterEach(() => jest.restoreAllMocks())` in `setup-after-env.js`, so manual
+  restoration is unnecessary.
+
+**Why**: Creating a test-only subclass introduces problems: (1) more boilerplate
+(e.g. redefining members with JSDoc), (2) you end up verifying the subclass
+rather than the base class you actually want to test, and (3) if the stub
+implementation and the real implementation drift apart, the test cannot notice.
+With `jest.spyOn()`, you can make the smallest possible substitution against the
+base class itself, keeping the intent clear.
+
+Correct example (overriding an abstract static getter / static method with
+spyOn):
+
+```js
+describe('BaseAuthorizationBuilder', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          override: {
+            schema: 'Bearer',
+            credential: 'credential-0001',
+          },
+          input: {
+            source: 'source-0001',
+          },
+        },
+        // ...
+      ]
+
+      test.each(cases)('source: $input.source', ({ override, input }) => {
+        jest.spyOn(BaseAuthorizationBuilder, 'schema', 'get')
+          .mockReturnValue(override.schema)
+        jest.spyOn(BaseAuthorizationBuilder, 'generateCredential')
+          .mockReturnValue(override.credential)
+
+        const builder = BaseAuthorizationBuilder.create(input)
+
+        expect(builder)
+          .toBeInstanceOf(BaseAuthorizationBuilder)
+      })
+    })
+  })
+})
+```
+
+Incorrect example (defining a test-only derived class to implement the abstract
+method):
+
+```js
+test.each(cases)('source: $input.source', ({ override, input }) => {
+  class DerivedAuthorizationBuilder extends BaseAuthorizationBuilder {
+    static get schema () {
+      return override.schema
+    }
+
+    static generateCredential ({ source }) {
+      return override.generateCredential({ source })
+    }
+  }
+
+  const builder = DerivedAuthorizationBuilder.create(input)
+
+  expect(builder)
+    .toBeInstanceOf(DerivedAuthorizationBuilder)
+})
+```
+
+## Combining with constructorSpy
+
+When verifying delegation to a constructor, combine an `jest.spyOn()` override
+with `constructorSpy.spyOn()`. Because a member replaced with spyOn is
+referenced through the prototype chain, the class returned by
+`constructorSpy.spyOn()` also picks up the same return value.
+
+```js
+test.each(cases)('source: $input.source', ({ override, input, expected }) => {
+  jest.spyOn(BaseAuthorizationBuilder, 'schema', 'get')
+    .mockReturnValue(override.schema)
+  jest.spyOn(BaseAuthorizationBuilder, 'generateCredential')
+    .mockReturnValue(override.credential)
+
+  const SpyClass = constructorSpy.spyOn(BaseAuthorizationBuilder)
+
+  SpyClass.create(input)
+
+  expect(SpyClass.__spy__)
+    .toHaveBeenCalledWith(expected)
+})
+```
+
+## Verifying Calls to a Function Passed as an Argument (callback / handler / deriver) with `jest.spyOn(args, key)`
+
+When verifying that a **function passed as an argument** to the subject under
+test (a `deriver` / callback / handler, etc.) was called correctly, do **not**
+create a `jest.fn()` and inject it into args. Instead, **define args normally
+with a real function, then spy on that function property with
+`jest.spyOn(args, '<key>')`**.
+
+- By default, `jest.spyOn()` **calls through to the real implementation**, so the
+  real function (the actual transformation) runs as-is. There is no need to
+  write out a stub implementation like `jest.fn(() => ...)`.
+- This makes the relationship clear: args holds "the real value," and the spy
+  merely observes the call.
+- This is consistent with this file's policy of preferring `jest.spyOn()`.
+- Name the variable holding the spy with a `~Spy` suffix
+  ([naming.md](./naming.md#variables-that-hold-a-spy)).
+- Placement: create the subject (the instance under test) first, then, after a
+  blank line, group "the args definition + its `spyOn`" together
+  ([aaa-pattern.md](./aaa-pattern.md#however-groups-of-statements-with-different-meanings-should-be-separated-by-blank-lines)).
+
+```js
+test.each(cases)('BaseCtor: $input.BaseCtor.name', ({ input, expected }) => {
+  const registry = new BoundCtorRegistry(input)
+
+  const args = {
+    /**
+     * @param {{ Ctor: new () => * }} params
+     * @returns {new () => *}
+     */
+    deriver: ({ Ctor }) => class extends Ctor {},
+  }
+  const deriverSpy = jest.spyOn(args, 'deriver')
+
+  registry.declareBoundCtor(args)
+
+  expect(deriverSpy)
+    .toHaveBeenCalledWith(expected)
+})
+```
+
+Incorrect example (creating a `jest.fn()` and injecting it into args):
+
+```js
+const deriverSpy = jest.fn(({ Ctor }) => class extends Ctor {}) // writing out a stub implementation
+const args = {
+  deriver: deriverSpy,
+}
+```
+
+## Exception (When It Is Acceptable to Define a Derived Class)
+
+A derived class may be defined only in cases that cannot be expressed with
+`jest.spyOn()` (e.g. when the thing being substituted extends beyond a member to
+the structure of the `class` itself). Even then, first consider whether it can
+be written with spyOn before resorting to this.
+
+A derived class may also be defined when **a single `describe()`'s `cases`
+requires multiple derived classes at the same time**. Since `jest.spyOn()` only
+swaps out members of a single class, situations that require several distinct
+concrete classes to exist **simultaneously** on a per-case basis (e.g. verifying
+the type differences among multiple subclasses themselves, or distinguishing
+by registering subclasses in a registry) cannot be expressed with spyOn. In
+this case, hold the derived classes in the elements of `cases` and iterate over
+them.
+
+### For a Getter That Returns a Function, Spy on "the Real Function It Returns"
+
+If a getter simply returns an existing function (e.g. a global function or a
+function from another module), trying to spy on the getter **itself** will fail
+to type-check. Jest's type definitions classify "a getter that returns a
+function" as a method-like key, excluding it from the `'get'` accessor overload
+(which only allows property-typed keys). As a result, the third argument
+`'get'` collapses to `never`, producing `TS2345` / `TS2339`
+(`mockReturnValue does not exist on never`) — it works at runtime but fails to
+type-check. (An `/** @type {any} */` cast may not disappear depending on the
+environment's TS settings, and even if it does, it stops catching property-name
+typos.)
+
+**Leave the getter alone, and instead call `jest.spyOn()` on the real function
+that the getter returns.** Since the real function is an ordinary data property
+(a function value), it type-checks fine as a method spy — no cast or derived
+class is needed. Because the getter returns the real function whenever it is
+called, the spied function is used automatically (since `jest.spyOn()` calls
+through to the real implementation by default, if you don't need side effects
+you can just verify the call with `toHaveBeenCalledWith`).
+
+```js
+// static get btoa () { return btoa } returns globalThis.btoa, so
+// spy on the real function globalThis.btoa rather than the getter.
+test.each(cases)('source: $input.source', ({ input, expected }) => {
+  const btoaSpy = jest.spyOn(globalThis, 'btoa')
+
+  const args = {
+    source: input.source,
+  }
+
+  BasicAuthorizationBuilder.generateCredential(args)
+
+  expect(btoaSpy)
+    .toHaveBeenCalledWith(expected.source)
+})
+```
+
+**Only** when the real function has no independently spyable location (e.g. the
+getter generates a new function every time, or the return value is a closure
+that cannot be referenced from outside), define a derived class inside
+`test.each()`, override the getter, and plant a spy (`jest.fn()`). Because
+spyOn is not used, the `never` problem never arises structurally, and type
+safety is preserved. Perform the call on the derived class side
+(`OverriddenClass.method(...)`), taking advantage of the fact that the
+overridden getter is referenced via `this`.
+
+```js
+// Fallback: only when the real function cannot be spied on independently
+test.each(cases)('source: $input.source', ({ input, expected }) => {
+  const someSpy = jest.fn()
+
+  class OverriddenClass extends SomeClass {
+    /** @override */
+    static get factory () {
+      return someSpy
+    }
+  }
+
+  OverriddenClass.run(input)
+
+  expect(someSpy)
+    .toHaveBeenCalledWith(expected)
+})
+```

--- a/kit/skills/core/hc-jest/references/naming.md
+++ b/kit/skills/core/hc-jest/references/naming.md
@@ -1,0 +1,293 @@
+# Naming (Variable and Naming Conventions)
+
+Naming conventions for variables, identifiers, and case properties in jest.
+Referenced from `SKILL.md`.
+
+## Notation of Class Members
+
+The `describe()` name of a member follows the notation in the table below. Prefix
+instance members with `#` and static members with `.`. Getters / setters use a
+`get:` / `set:` prefix (e.g. `.get:schema` instead of `.schema`).
+
+This notation is **governed by "Notation of Class Members" in the documentation
+convention**. The table below restates it in the context of jest; when the
+governing table changes, align this one with it.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+
+When referring to a member **within the prose** of `describe()` / `test()` at the
+behavior layer, **follow the 2nd-level `describe()` format** as well (append `()`
+for methods).
+
+```js
+// Good example: append () for methods
+describe('should call JSON.stringify() with value and replacer', () => {})
+
+// Bad example: no ()
+describe('should call JSON.stringify with value and replacer', () => {})
+```
+
+## Test Case Variables
+
+- Name the array of test cases `cases`.
+- For the inner cases of a double loop, use a prefixed `~Cases` name (e.g.
+  `valueHashCases`, `betaCases`). The prefix represents the target being iterated
+  over on the inner side (the method argument).
+
+## Property Names of Case Objects
+
+Use **only** the following four top-level properties on the element objects of
+`cases`. Do not invent names like `params` / `args`. However, for the outer
+`cases` of a double loop only, it is also acceptable to have a prefixed inner
+`cases` property (`~Cases`) in addition to the ones below.
+
+| property | purpose |
+| --- | --- |
+| `override` | Used to supplement an abstract method with a stub implementation when testing an abstract class. Not used for concrete classes. |
+| `input` | The argument(s) passed to the subject under test (constructor / method). |
+| `tally` | A value that **serves as both** `input` and `expected`. When the same value is both passed in and used as the expected value, combine it into a single `tally` instead of splitting it into `input` and `expected` (e.g. pass it to `create(tally)` and also verify it with `toHaveBeenCalledWith(tally)`). The name means "tally" in the sense of a matching token, expressing the intent that the passed value and the expected value are **checked to be identical**. This name was chosen as a short word that does not collide with common domain vocabulary. Use it **only when the passed value and the expected value are the same**; if the implementation transforms the argument such that the two differ, do not use `tally` — split it into `input` / `expected`. |
+| `expected` | The expected return value / property value. |
+
+### `tally` is only for when the "value passed to the subject" and "expected value" are the **same object reference / same value**
+
+**Mechanical check (highest priority; if this is not satisfied, it is not `tally`)**:
+`tally` must **appear in both** Arrange/Act (where the value is passed to the
+subject) and Assert (where it is passed to a matcher)
+(`member(tally)` … `expect(...).toXxx(tally)`).
+If `tally` appears **in only one of the two**, that is a misuse.
+
+- If `tally` appears only in Assert (the matcher) — i.e. Act passes a different
+  value such as `input` — then it is **expected-value only**, so it should be
+  `expected`. Example: calling `create(input)` and then asserting
+  `expect(spy).toHaveBeenCalledWith(tally)` is wrong → use `expected`.
+- If `tally` appears only in Act (Assert checks a different or derived value),
+  then the value being passed should be `input`.
+- What matters is **whether `tally` appears in both Act and Assert**, not the
+  shape of the destructuring in `cases`. It is fine for `tally` to coexist with
+  other properties, as in `({ input, tally })` or `({ tally, expected })` (passing
+  a different argument via `input`, or checking a different value via
+  `expected`, while `tally` still appears on both sides).
+- If the member **transforms, infers, or renames the input to produce the
+  expected value** (`rawSchema` → an inferred `BootScalar`, `null` →
+  `SentinelScalar`, receiving a value under a different property name, etc.),
+  do not use `tally` even if **the value happens to match in some cases**
+  (`IntegerScalar` → `IntegerScalar`). Once a transformation is involved, the
+  "value passed" and the "expected value" are different things. If even one
+  case in the same `cases` array undergoes an effective transformation (e.g.
+  `null` → `SentinelScalar`), treat the entire `cases` array as `input` /
+  `expected`.
+
+`tally` may only be used when the thing **passed to the subject under test** and
+the thing **expected in the assertion** are **exactly the same value** (the same
+scalar, or the same object reference). The criterion is not "a string that looks
+the same" but "the very same value."
+
+In particular, when the **subject under test receives an object and the expected
+value is a scalar nested inside it** (or vice versa), the passed value (the
+object) and the expected value (the scalar) are **different things**, so `tally`
+cannot be used. Split into `input` / `expected`.
+
+- Decision procedure: line up "the `X` passed to `subjectUnderTest(X)`" and "the
+  `Y` in `expect(...).toXxx(Y)`". If `X` and `Y` are the same value, use `tally`;
+  if they differ in any way (object vs. its inner scalar, only some properties,
+  after transformation, etc.), use `input` / `expected`.
+- The value of `tally` should be **what is passed as-is to the subject under
+  test** (i.e. also expected as-is). If the structure wraps a single value when
+  passing it, e.g. `{ prop: tally }`, then the passed side is an object while the
+  expected side is a scalar, making them non-identical — do not use `tally`;
+  split into `input` / `expected`. If both the passed and expected sides are
+  objects, put **the whole object** into `tally` (do not put only the inner
+  contents of a wrapper like `{ prop: value }` into `tally`).
+- `tally` may have **multiple named members**
+  (`tally: { alpha: { id: ... }, beta: { value: '...' } }`). If each member is
+  used **as-is** (passed without modification, and asserted as-is), then
+  referencing `tally.alpha` is "used wholesale," not "partial use."
+- "Partial use" means passing a member after **wrapping it in a different
+  structure / extracting only part of it** — i.e. **after processing** it. For
+  example, wrapping it as in `new SomeClass({ replacer: tally.replacer })` or
+  `method({ value: tally.value })` is not "as-is," so use `input` instead of
+  `tally` in that case.
+
+```js
+// OK: each member is passed as-is and asserted as-is (used wholesale)
+test.each(cases)('id: $tally.alpha.id', ({ tally }) => {
+  const spy = jest.spyOn(target, 'method')
+
+  target.run(tally.alpha, tally.beta) // pass as-is
+
+  expect(spy)
+    .toHaveBeenCalledWith(tally.alpha, tally.beta) // assert as-is
+})
+
+// NG: a member is wrapped again before being passed (not "as-is") → use input
+test.each(cases)('value: $input.value', ({ input }) => {
+  const stringifier = new SomeClass({ replacer: input.replacer })
+  stringifier.method({ value: input.value })
+  // ...
+})
+```
+
+```js
+// NG: tally cannot be used here. What is passed is { source } (an object),
+//     and what is expected is btoa's argument = source (a scalar) — they differ.
+const cases = [
+  { tally: 'source-0001' },
+]
+test.each(cases)('...', ({ tally }) => {
+  Builder.generateCredential({ source: tally }) // pass an object
+  expect(btoaSpy).toHaveBeenCalledWith(tally)    // expect a scalar → not identical
+})
+
+// OK: split into input (the object passed) and expected (the scalar arg to btoa)
+const cases = [
+  {
+    input: { source: 'source-0001' },
+    expected: 'source-0001',
+  },
+]
+test.each(cases)('source: $input.source', ({ input, expected }) => {
+  Builder.generateCredential(input)
+  expect(btoaSpy).toHaveBeenCalledWith(expected)
+})
+
+// Example of tally used correctly: the passed value and expected value are the same scalar
+const cases = [
+  { tally: 100001 },
+]
+test.each(cases)('id: $tally', ({ tally }) => {
+  SomeClass.create(tally)                  // value passed
+  expect(SpyClass.__spy__).toHaveBeenCalledWith(tally) // expect the same value
+})
+
+// NG: a single value is put in tally and then wrapped as { replacer: tally } when passed.
+//     What is passed is { replacer } (an object), and what is expected is replacer (a scalar) — they differ.
+const cases = [
+  { tally: alphaReplacer },
+]
+test.each(cases)('...', ({ tally }) => {
+  const instance = new SomeClass({ replacer: tally }) // pass an object
+  expect(instance).toHaveProperty('replacer', tally)  // expect a scalar → not identical
+})
+
+// OK: split into input (the value passed) and expected (the property value)
+const cases = [
+  {
+    input: { replacer: alphaReplacer },
+    expected: alphaReplacer,
+  },
+]
+test.each(cases)('replacer: $input.replacer', ({ input, expected }) => {
+  const instance = new SomeClass({ replacer: input.replacer })
+  expect(instance).toHaveProperty('replacer', expected)
+})
+
+// OK: if the passed object and the expected object are the same, put that "object" into tally
+const cases = [
+  { tally: { replacer: alphaReplacer } },
+]
+test.each(cases)('replacer: $tally.replacer', ({ tally }) => {
+  SomeClass.create(tally)                              // pass the object
+  expect(SpyClass.__spy__).toHaveBeenCalledWith(tally) // expect the same object
+})
+```
+
+## Act's Return Value
+
+- The variable that receives the return value in the Act step of the AAA pattern
+  should be named `received`, not `actual`.
+- `received` is **the value passed to `expect()`** (the value being asserted). If
+  you assert the Act return value itself, that is what should be `received`. If
+  you assert a **property** of the return value, receive the return value in a
+  variable with a descriptive name (PascalCase for a class) first, then set
+  `const received = <var>.<prop>`
+  ([aaa-pattern.md](./aaa-pattern.md#pass-a-variable-to-expect-not-an-expression)).
+
+## Naming the args Object
+
+The variable in Arrange that assembles the argument object to pass to the
+subject under test should, **in principle**, be named `args`.
+
+**However, if a single `test` builds more than one args object** (e.g. one for
+the constructor and one for a method — i.e. the destination splits across two or
+more targets), `args` alone cannot distinguish them, so name each build as **the
+destination member's name + `Args`**. Do not use role-based generic names like
+`propertyArgs` / `methodArgs`.
+
+- **Only one build** → `args`.
+- **Multiple builds** → name each as the destination member's name + `Args`. The
+  constructor uses `constructorArgs`; the method `foo()` uses `fooArgs` (e.g.
+  `buildPathname()` → `buildPathnameArgs`).
+- Splitting is needed when a single `input` is passed to multiple destinations —
+  see
+  [structure.md](./structure.md#if-input-mixes-properties-and-arguments-split-into-args-constructorargs--methodnameargs)
+  for details.
+
+```js
+// Only one build → args
+const args = {
+  value: input.value,
+}
+
+const received = stringifier.stringifyBody(args)
+```
+
+```js
+// Multiple builds (splitting one input into constructor and method parts)
+// → destination member's name + Args
+const constructorArgs = {
+  templatePathname: input.templatePathname,
+}
+const buildPathnameArgs = {
+  valueHash: input.valueHash,
+}
+
+const builder = new PathnameBuilder(constructorArgs)
+
+const received = builder.buildPathname(buildPathnameArgs)
+```
+
+> Note: Multiple builds occur when a single `input` **mixes constructor
+> properties and method arguments** and both need to be built. If `input` maps
+> 1:1 to the constructor **and can be passed directly**, there is only one build
+> (for the method), and `args` is used (the same applies to a double loop: if the
+> outer input matches the constructor, e.g. `{ BaseCtor }`, pass it directly with
+> `new SomeClass(input)`, and only build `args` for the inner argument).
+
+## Variables That Hold a Spy
+
+This convention applies only to variables whose value is a `jest.fn()` (i.e. a
+spy/mock **function** itself). **The criterion is "does the held value equal
+`jest.fn()`"**, and any variable meeting that criterion must **without
+exception** get a `~Spy` suffix.
+
+- Name variables holding a `jest.fn()` with a `~Spy` suffix (e.g. `btoaSpy`,
+  `fetchSpy`). Do not use other terms like `tally`. This makes it explicit by
+  name that the subject of call verification "is a function spy."
+- If held in a constant (upper snake case), also uppercase the suffix, giving
+  `XXXX_XXX_SPY` (e.g. `BTOA_SPY`, `FETCH_HANDLER_SPY`). This matches the naming
+  convention's casing while still conveying the `~Spy` meaning via `_SPY`.
+- `constructorSpy.spyOn()` returns a **class** (not a `jest.fn()`), so it falls
+  **outside** this convention — it remains `SpyClass` (not because it is
+  excluded/exempted, but because it never meets the criterion in the first
+  place). The actual function spy can be retrieved as `SpyClass.__spy__`. If you
+  bind this `__spy__` to a variable, it is equivalent to a `jest.fn()`, so give
+  it a `~Spy` suffix. See the constructorSpy section of [mocks.md](./mocks.md)
+  for details.
+
+```js
+const btoaSpy = jest.fn()
+
+// ...
+
+expect(btoaSpy)
+  .toHaveBeenCalledWith(expected.source)
+```

--- a/kit/skills/core/hc-jest/references/prohibit.md
+++ b/kit/skills/core/hc-jest/references/prohibit.md
@@ -1,0 +1,105 @@
+# Prohibit (Prohibited Practices)
+
+Collects the notation and matchers that **must not** be used in jest tests.
+Referenced from `SKILL.md`. Each individual prohibition is a consequence of the
+QA-stance core principle in [SKILL.md](../SKILL.md): "write tests so that they
+would catch it if the implementation were wrong."
+
+> For prohibited syntax related to "don't write logic in tests" — control flow,
+> unverified logic, helper definitions, etc. — see
+> [anti-pattern.md](./anti-pattern.md). This file covers other prohibitions
+> (such as overly loose assertions).
+
+## Do Not Use Loose Matchers (`expect.anything()` / `expect.any(Object)`)
+
+**`expect.anything()`** and **`expect.any(Object)`** are **prohibited**. Both are
+matchers that **accept a wide range of values without verifying anything
+specific**, letting a test pass even when the implementation is wrong (a
+violation of the QA stance).
+
+- **`expect.anything()`** matches **anything except** `null` / `undefined`. Even
+  if the implementation returns the wrong object, string, or number, the test
+  will **pass** as long as it's non-null. It cannot detect hardcoding or
+  regressions — the assertion effectively "does nothing."
+- **`expect.any(Object)`** only checks "is it an instance of Object." In JS,
+  almost everything is an Object (`{}` / arrays / functions / Date / RegExp,
+  ...), so it **barely constrains anything**. Even if the shape of the return
+  value regresses into something completely different, the test passes as long
+  as the type matches.
+
+Do not loosen the assertion because "writing the expected value as a literal is
+tedious" or "the value is runtime-generated and can't be written out." Always
+pin it to a **concrete value** or **concrete type**.
+
+- **If there is a concrete value** → pass a literal `expected` to `toBe()` /
+  `toEqual()` to pin the value (the same root as the uniqueness convention in
+  [test-cases.md](./test-cases.md)).
+- **If you want to pin the type** (e.g. the fixed value is an object with a
+  unique reference) → pin it with a **concrete type**, e.g.
+  `toBeInstanceOf(WeakMap)`, instead of `expect.any(Object)`
+  ([structure.md](./structure.md#if-the-fixed-value-is-an-object-pin-it-by-type-tobeinstanceof)).
+- **For a runtime-generated value** (e.g. the same reference returned by
+  memoization) → bind the first return value to `expected` and verify identity
+  with `toBe(expected)`
+  ([structure.md](./structure.md#methods-that-memoize-and-return-the-same-reference-should-be-memoized)).
+
+```js
+// ❌️ Letting the value pass through unchecked (passes even if the implementation is wrong)
+expect(received)
+  .toEqual(expect.anything())
+
+expect(received)
+  .toEqual(expect.any(Object))
+
+// ✅️ Pin a concrete value
+expect(received)
+  .toBe('Basic')
+
+// ✅️ To pin the type, use a concrete type
+expect(received)
+  .toBeInstanceOf(WeakMap)
+```
+
+## Do Not Write `jest.fn()` Directly Inline Inside `test()`
+
+Creating and using a `jest.fn()` inside `test()` (injecting it into args,
+plugging it into a member) is **prohibited in principle**. Mocks and stubs
+should spy on **a real seam** (a member of the real class / a function property
+of args / a global function, etc.) using `jest.spyOn()`. There are three
+reasons for this.
+
+- **It amounts to writing out a stub implementation**: `jest.fn()` is an empty
+  fake function; to give it meaning you end up having to
+  **hand-write a stub implementation** like `jest.fn(() => ...)`. This is a copy
+  of the real thing, and if it drifts, nobody notices — it introduces
+  **unverified logic** into the test ([anti-pattern.md](./anti-pattern.md) /
+  a violation of the QA stance). `jest.spyOn()` **calls through to the real
+  implementation** by default, so no stub implementation is needed.
+- **It is not restored automatically**: `jest.spyOn()` is restored after every
+  test via `afterEach(() => jest.restoreAllMocks())`, but a member into which a
+  `jest.fn()` was plugged inline is not restored, becoming a source of
+  **cross-test contamination**.
+- **It isn't tied to a real seam**: `jest.fn()` is a fake not tied to
+  anything real, so it hides whether the actual collaborator works.
+  `jest.spyOn()` targets a real, existing seam, observing calls while letting
+  the real thing run.
+
+See [mocks.md](./mocks.md) for the concrete techniques
+(`jest.spyOn(args, key)` / `constructorSpy` / spying on global functions) and
+for the **one exception** where `jest.fn()` is allowed (only when there is no
+seam through which the real function can be spied on independently, override a
+getter in a derived class and plant a `jest.fn()` there).
+
+```js
+// ❌️ Creating a jest.fn() and injecting it into args (writing out a stub implementation)
+const deriverSpy = jest.fn(({ Ctor }) => class extends Ctor {})
+const args = {
+  deriver: deriverSpy,
+}
+
+// ✅️ Define args with a real function, and spyOn its function property
+const args = {
+  deriver: ({ Ctor }) => class extends Ctor {},
+}
+const deriverSpy = jest.spyOn(args, 'deriver')
+```

--- a/kit/skills/core/hc-jest/references/structure.md
+++ b/kit/skills/core/hc-jest/references/structure.md
@@ -1,0 +1,1517 @@
+# Structure (describe / test structure)
+
+Conventions for assembling and nesting describe / test blocks in Jest.
+Referenced from `SKILL.md`. See [naming.md](./naming.md) for variables and naming.
+
+## describe() Structure
+
+Put the class-name describe() on the **outside** and the member describe() on the
+**inside**. However, the class-name describe() and the member describe() must
+correspond **one-to-one**. In other words, **repeat** the class-name describe() for
+each member, and put only **one** member into each class-name describe().
+
+- Do not bundle multiple members into a single class-name describe().
+- The nesting order is `describe(class) > describe(member) > describe(behavior) > test()`.
+- Name the behavior-layer describe() after the expected behavior using
+  **`should [verb]`** (e.g. `describe('should keep property')` /
+  `describe('should call constructor')`). Do not use `to [verb]`. However, when the
+  behavior **depends on a precondition**, insert `describe('when [precondition]')` and
+  express it via `test('should [verb]')` inside it (e.g. `when not inherited` /
+  `when called as is`).
+
+### For classes that inherit, place `describe('inheritance')` first
+
+If the class under test `extends` another class, place `describe('inheritance')` as
+the **first** class-name describe() to verify that it inherits from the base class.
+Place it **before** the other member describe()s.
+
+- Since inheritance does not depend on input, do not use `cases` / `test.each()` —
+  place a single `test()`.
+- Verify inheritance via the prototype chain (that `SubClass.prototype` is an instance
+  of the base class). Use the `toBeInstanceOf()` assertion.
+- The nesting order is `describe(class) > describe('inheritance') > test()`.
+- Import the base class as well.
+
+```js
+import BasicAuthorizationBuilder from '.../concretes/BasicAuthorizationBuilder.js'
+
+import BaseAuthorizationBuilder from '.../BaseAuthorizationBuilder.js'
+
+describe('BasicAuthorizationBuilder', () => {
+  describe('inheritance', () => {
+    test('should be correct class', () => {
+      const received = BasicAuthorizationBuilder.prototype
+
+      expect(received)
+        .toBeInstanceOf(BaseAuthorizationBuilder)
+    })
+  })
+})
+```
+
+### For throws on abstract members, insert `when not inherited`
+
+When verifying that an abstract member (a static getter / method that throws when
+called on the base class as-is, without being overridden by a subclass) throws, insert
+`describe('when not inherited')` as the behavior layer to make explicit the
+precondition that it was "called **without being inherited (overridden)**".
+
+- Express the calling condition (precondition) with `describe('when not inherited')`,
+  and express the behavior with `test('should throw error')` inside it.
+- The nesting order is
+  `describe(class) > describe(member) > describe('when not inherited') > test()`.
+- If you are simply verifying that it throws, `cases` / `test.each()` are unnecessary
+  since the throw does not depend on input. Just place a single `test()` inside the
+  describe() that expresses the precondition.
+
+```js
+describe('BaseAuthorizationBuilder', () => {
+  describe('.get:schema', () => {
+    describe('when not inherited', () => {
+      test('should throw error', () => {
+        expect(() => BaseAuthorizationBuilder.schema)
+          .toThrow('BaseAuthorizationBuilder.get:schema must be inherited')
+      })
+    })
+  })
+})
+```
+
+- However, if the thrown error message **varies by derived class** (e.g. it includes
+  `this.name` as in `` `${this.name}...` ``), turn that variation into `cases`.
+  Prepare the base class and several derived classes with different names, and verify
+  that the expected message changes per class. Whether it is acceptable to define a
+  derived class follows "When it is acceptable to define a derived class" in
+  [mocks.md](./mocks.md) (since a single `describe()`'s `cases` needs several derived
+  classes simultaneously, it is acceptable to define them).
+
+```js
+describe('BaseAuthorizationBuilder', () => {
+  describe('.get:schema', () => {
+    describe('when not inherited', () => {
+      class AlphaAuthorizationBuilder extends BaseAuthorizationBuilder {}
+
+      class BetaAuthorizationBuilder extends BaseAuthorizationBuilder {}
+
+      const cases = [
+        {
+          input: { Builder: BaseAuthorizationBuilder },
+          expected: 'BaseAuthorizationBuilder.get:schema must be inherited',
+        },
+        {
+          input: { Builder: AlphaAuthorizationBuilder },
+          expected: 'AlphaAuthorizationBuilder.get:schema must be inherited',
+        },
+        {
+          input: { Builder: BetaAuthorizationBuilder },
+          expected: 'BetaAuthorizationBuilder.get:schema must be inherited',
+        },
+      ]
+
+      test.each(cases)('Builder: $input.Builder.name', ({ input, expected }) => {
+        expect(() => input.Builder.schema)
+          .toThrow(expected)
+      })
+    })
+  })
+})
+```
+
+- If the abstract member is an **instance method** (`#method()`, not static),
+  **instantiate** it before calling. Since the constructor arguments are irrelevant to
+  the verification, fill them with neutral values (the same idea as
+  [Isolate the property under test](#isolate-the-property-under-test)). If the message
+  varies with `this.constructor.name`, turn the derived classes into `cases` and
+  create an instance with `new input.Stringifier(...)`.
+
+```js
+describe('BaseRequestBodyStringifier', () => {
+  describe('#stringifyBody()', () => {
+    describe('when not inherited', () => {
+      class AlphaRequestBodyStringifier extends BaseRequestBodyStringifier {}
+
+      class BetaRequestBodyStringifier extends BaseRequestBodyStringifier {}
+
+      const cases = [
+        {
+          input: { Stringifier: BaseRequestBodyStringifier },
+          expected: 'BaseRequestBodyStringifier#stringifyBody() must be inherited',
+        },
+        {
+          input: { Stringifier: AlphaRequestBodyStringifier },
+          expected: 'AlphaRequestBodyStringifier#stringifyBody() must be inherited',
+        },
+        {
+          input: { Stringifier: BetaRequestBodyStringifier },
+          expected: 'BetaRequestBodyStringifier#stringifyBody() must be inherited',
+        },
+      ]
+
+      test.each(cases)('Stringifier: $input.Stringifier.name', ({ input, expected }) => {
+        const stringifier = new input.Stringifier({
+          replacer: null, // Neutral value. Since throwing is what's under test, the value can be anything
+        })
+        const args = {
+          value: {},
+        }
+
+        expect(() => stringifier.stringifyBody(args))
+          .toThrow(expected)
+      })
+    })
+  })
+})
+```
+
+### For fixed-value static getters / static properties, insert `when called as is`
+
+When verifying a static getter that returns a fixed value (constant), or a static
+property initialized with a fixed value (e.g. `static schema = 'Basic'` /
+`static pool = new WeakMap()`), insert `describe('when called as is')` as the behavior
+layer to make explicit the precondition that it was "**referenced as-is**". Place a
+single `test('should ...')` inside it and assert the value (whether you write the
+value directly in the matcher or bind it to `const expected` is decided by the rule in
+[aaa-pattern.md](./aaa-pattern.md#write-expected-value-literals-inline-if-single-line-bind-to-const-expected-if-multi-line)).
+
+- Since fixed values do not depend on input, do not use `cases` / `test.each()`. Do not
+  create a `cases` array with `input` / `expected`. Whether the expected value is
+  written directly in the matcher or bound to `const expected` is decided by whether
+  the value is single-line or multi-line
+  ([aaa-pattern.md](./aaa-pattern.md#write-expected-value-literals-inline-if-single-line-bind-to-const-expected-if-multi-line)).
+- Use the same form for a static property (not a getter) too. The member describe
+  notation follows [naming.md](./naming.md): `.staticProperty` (getters are
+  `.get:staticGetter`). `when called as is` may be used as-is for property references
+  too.
+- The nesting order is
+  `describe(class) > describe(member) > describe('when called as is') > test()`.
+- Only when there is an exceptional reason (the getter's value actually varies with
+  state, etc.) may you drop this form for `cases` / `test.each()`.
+
+```js
+describe('BasicAuthorizationBuilder', () => {
+  describe('.get:schema', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = BasicAuthorizationBuilder.schema
+
+        expect(received)
+          .toBe('Basic')
+      })
+    })
+  })
+})
+```
+
+#### If the fixed value is an "object", pin it by type (`toBeInstanceOf`)
+
+If the fixed value is a **primitive** (string, number, etc.), pin the exact value
+itself with `test('should be fixed value')` + `toBe(<fixed value>)`. On the other
+hand, if the fixed value is an **object such as `WeakMap` / `Map` / `Set`**, the
+reference is unique per instance and you cannot write `toBe(<literal>)`, so **pin it
+by type** instead.
+
+- The behavior (`test`) name expresses the **type**, not the value
+  (`should be a WeakMap`).
+- Use `toBeInstanceOf(<type>)` as the assertion, not `toBe()`.
+- This applies to cases where a static property initializes a memoization pool, etc.
+  Memoization behavior such as "the same reference is returned on every call" is
+  verified on the **method side** that uses it, not on the property alone
+  (see [Methods that memoize and return the same reference](#methods-that-memoize-and-return-the-same-reference-should-be-memoized)).
+
+```js
+describe('BoundCtorRegistry', () => {
+  describe('.BoundCtorPool', () => {
+    describe('when called as is', () => {
+      test('should be a WeakMap', () => {
+        const received = BoundCtorRegistry.BoundCtorPool
+
+        expect(received)
+          .toBeInstanceOf(WeakMap)
+      })
+    })
+  })
+})
+```
+
+### Instance getters require `test.each()` (the variable element is the instance)
+
+An instance getter (e.g. `get Ctor () { return this.constructor }`), or a getter whose
+value **varies depending on the instance's state or type**, is not a "fixed value". Do
+not reduce it to a single `test()` under `when called as is` — instead, put the
+**variable element (i.e. which instance it is) into `cases` and drive it with
+`test.each()`**.
+
+- Do not shrink it to a single `test()` just because "the base class currently being
+  verified always yields the same value". That is a **shortcut justified by the
+  implementation** — it would even pass with a hardcoded implementation like
+  `return BoundCtorRegistry`, and would fail to verify that the getter returns
+  `this.constructor` (the contract) (see the QA principle in
+  [SKILL.md](../SKILL.md)).
+- For an instance getter, the variable element is "which class the instance is an
+  entity of." Turn instances of the **base class and several derived classes** into
+  cases, and confirm the getter returns the correct value for each. Since several
+  derived classes are needed simultaneously, it is acceptable to define them following
+  "When it is acceptable to define a derived class" in [mocks.md](./mocks.md).
+- A single `test()` (`when called as is`) is permitted only for the case above —
+  [fixed-value static getters / static properties](#for-fixed-value-static-getters--static-properties-insert-when-called-as-is)
+  — which return a constant **regardless of input or state**.
+
+```js
+describe('BoundCtorRegistry', () => {
+  describe('#get:Ctor', () => {
+    class SampleBaseCtor {}
+
+    class AlphaBoundCtorRegistry extends BoundCtorRegistry {}
+    class BetaBoundCtorRegistry extends BoundCtorRegistry {}
+
+    describe('should be constructor of instance', () => {
+      const cases = [
+        {
+          input: {
+            Registry: BoundCtorRegistry,
+          },
+          expected: BoundCtorRegistry,
+        },
+        {
+          input: {
+            Registry: AlphaBoundCtorRegistry,
+          },
+          expected: AlphaBoundCtorRegistry,
+        },
+        {
+          input: {
+            Registry: BetaBoundCtorRegistry,
+          },
+          expected: BetaBoundCtorRegistry,
+        },
+      ]
+
+      test.each(cases)('Registry: $input.Registry.name', ({ input, expected }) => {
+        const registry = new input.Registry({
+          BaseCtor: SampleBaseCtor,
+        })
+
+        const received = registry.Ctor
+
+        expect(received)
+          .toBe(expected) // Same reference
+      })
+    })
+  })
+})
+```
+
+**Why repeat it (important)**: This is an optimization for the human reader. Even as
+the test file grows long, a class-name describe() always sits directly above every
+member describe(), so no matter where you stop while fast-scrolling, "which class and
+what am I looking at" is always visible on screen. If a single class describe() wraps
+all members, the class context scrolls off screen the moment you pass the top, and you
+need to scroll back up to tell which class you're in. Think of it as achieving a
+"sticky header" through syntax. We accept that the class name is duplicated in the
+Jest output, in favor of readability.
+
+Correct example:
+
+```js
+describe('PathnameBuilder', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      test.each(cases)('...', () => { /* ... */ })
+    })
+  })
+})
+
+describe('PathnameBuilder', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      test.each(cases)('...', () => { /* ... */ })
+    })
+  })
+})
+
+describe('PathnameBuilder', () => {
+  describe('#buildPathname()', () => {
+    describe('should interpolate placeholder', () => {
+      test.each(cases)('...', () => { /* ... */ })
+    })
+  })
+})
+```
+
+Incorrect example (a single class-name describe() bundling multiple members):
+
+```js
+describe('PathnameBuilder', () => {
+  describe('constructor', () => { /* ... */ })
+  describe('.create()', () => { /* ... */ })
+  describe('#buildPathname()', () => { /* ... */ })
+})
+```
+
+### Methods that take arguments require `test.each()` (the variable element is the argument)
+
+For a method whose output **depends on its arguments** (static or instance, whether
+`create(args)` / `buildSchema(args)` — anything whose result is determined by the
+value passed in), you must **not** fix a single input in a single `test()`. Turn the
+argument into the variable element as `cases`, and drive **two or more inputs** with
+`test.each()`. With only one input, an implementation that ignores the argument and
+hardcodes the value would still pass (the QA stance in [SKILL.md](../SKILL.md)).
+Whereas [Instance getters require `test.each()`](#instance-getters-require-testeach-the-variable-element-is-the-instance)
+has "the variable element is the instance," here "the variable element is the
+argument."
+
+- Even when you insert `describe('when ...')` per branch (dispatch), the inside must
+  still use **`test.each()` with ≥2 inputs**. For `when schema is array`, pass two or
+  more different arrays; for `when value is scalar constructor`, pass two or more
+  different constructors — showing that the argument actually has an effect.
+- A single `test()` is permitted only for behavior that **does not depend on input**:
+  [when not inherited](#for-throws-on-abstract-members-insert-when-not-inherited) (throwing
+  does not depend on arguments) /
+  [when called as is](#for-fixed-value-static-getters--static-properties-insert-when-called-as-is)
+  (fixed value) / inheritance / default-value filling when called with no arguments,
+  etc.
+- If an argument is passed but **that axis is a neutral collaborator uninvolved in the
+  behavior**, drive the axis that *is* involved (a different argument/property) with
+  `test.each()` and fix only the neutral argument.
+
+```js
+// Bad: fixing a method that takes arguments to a single input
+describe('when schema is array', () => {
+  test('should build array schema', () => {
+    const received = SomeClass.buildSchema({ schema: [Alpha, Beta] })
+    // Would still pass even with a hardcoded `return [Alpha, Beta]`
+  })
+})
+
+// Good: drive the argument with test.each (2+ inputs)
+describe('when schema is array', () => {
+  const cases = [
+    {
+      input: {
+        schema: [Alpha, Beta],
+      },
+      expected: [Alpha, Beta],
+    },
+    {
+      input: {
+        schema: [Gamma, Delta],
+      },
+      expected: [Gamma, Delta],
+    },
+  ]
+
+  test.each(cases)('schema: $input.schema', ({ input, expected }) => {
+    const received = SomeClass.buildSchema(input)
+
+    expect(received)
+      .toEqual(expected)
+  })
+})
+```
+
+## Define shared fixtures directly under the member describe
+
+If the same fixture variable (e.g. `alphaReplacer`) is used by **multiple behavior
+describes** under the same member, define it **once, directly under the member
+(second-level) describe**, and share it. Do not repeat the same declaration for each
+behavior.
+
+- A variable used by only one behavior belongs inside that behavior's describe (do not
+  force-hoist it). Only lift it up to the member level when sharing actually occurs.
+
+```js
+describe('BaseRequestBodyStringifier', () => {
+  describe('.create()', () => {
+    /** @type {(key: string, value: *) => *} */
+    const alphaReplacer = (key, value) => value
+
+    const betaReplacer = ['id', 'name']
+
+    describe('should be an instance of own class', () => {
+      const cases = [
+        // Shares alphaReplacer / betaReplacer / null
+      ]
+      // ...
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        // Shares the same alphaReplacer / betaReplacer
+      ]
+      // ...
+    })
+  })
+})
+```
+
+## Do not define shared variables outside `describe()` (at file scope)
+
+A variable used across multiple `describe()`s must **not** be defined outside all `describe()`s (i.e. at file scope
+/ module top level) — for example, placing a derived binding at the top of the file and reusing it across every
+describe. Only imports are allowed at file scope. A variable you want to share must be **defined fresh inside each
+`describe()` that uses it** (when sharing across behaviors within the same member, do so [once directly under the
+member describe](#define-shared-fixtures-directly-under-the-member-describe); when sharing across members, redefine
+it in each member describe).
+
+- **Why**: File-scope shared state is hard to trace — it's unclear which `describe()`
+  / `test()` depends on it — and it invites implicit coupling and contamination
+  between tests. Confining it inside the describe block means reading just that block
+  is enough to know the full precondition (this also aligns with the sticky-header
+  policy of repeating the class-name describe per member).
+- Even if you're worried about the cost of creation (e.g. building a derived class via
+  a factory), it's fine to define it fresh each time (it is memoized / correctness is
+  the priority in tests).
+- Imports (the class under test, the base class, test declaration classes, etc.) are
+  side-effect-free bindings, so they are fine at file scope.
+
+```js
+// Bad: a shared binding at file scope (outside all describes)
+const BoundClass = SomeClass.of(SomeCollaborator)
+
+describe('SomeClass', () => {
+  describe('#alpha()', () => {
+    // Uses BoundClass
+  })
+})
+
+describe('SomeClass', () => {
+  describe('#beta()', () => {
+    // This one also uses BoundClass
+  })
+})
+```
+
+```js
+// Good: define it in each describe that needs it (imports remain at file scope)
+import SomeCollaborator from '.../SomeCollaborator.js'
+
+describe('SomeClass', () => {
+  describe('#alpha()', () => {
+    const BoundClass = SomeClass.of(SomeCollaborator)
+    // ...
+  })
+})
+
+describe('SomeClass', () => {
+  describe('#beta()', () => {
+    const BoundClass = SomeClass.of(SomeCollaborator)
+    // ...
+  })
+})
+```
+
+## Constructor Tests
+
+In the constructor's `should keep property`, insert one `describe('#<propertyName>')`
+**per** property retained, and write `cases` / `test.each()` inside it.
+
+- If there are multiple properties, line them up as `#alpha`, `#beta`, and so on.
+- The nesting order is
+  `describe(class) > describe('constructor') > describe('should keep property') > describe('#<property>') > test()`.
+- Use `toHaveProperty()` as the assertion, not `toBe()`.
+
+```js
+test.each(cases)('alpha: $input.alpha', ({ input, expected }) => {
+  const instance = new SomeClass(input)
+
+  expect(instance)
+    .toHaveProperty('alpha', expected)
+})
+```
+
+```js
+describe('PathnameBuilder', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#alpha', () => {
+        const cases = [
+          // ...
+        ]
+
+        test.each(cases)('alpha: $input.alpha', ({ input, expected }) => {
+          // ...
+        })
+      })
+
+      describe('#beta', () => {
+        // ...
+      })
+    })
+  })
+})
+```
+
+### Isolate the property under test
+
+Even when a constructor takes multiple arguments, put **only the property under
+test** into the `input` of each `#<property>`'s `cases`. Do not write other required
+arguments into `cases` — fill them with a **neutral value** (such as an empty string)
+when assembling `args` in the test body.
+
+- Do not mix unrelated arguments into `input` (do not write `credential` into the
+  `#scheme` cases).
+- Assemble the argument object passed to the constructor as `args` inside the test,
+  filling the target property from `input` and everything else with a default value.
+
+**Why**: To keep clear, for each property's test, what is being varied and what is
+being verified. It minimizes `cases`, and makes the variable under test obvious at a
+glance.
+
+#### If there is no addition/removal of properties, pass `input` as-is
+
+Assembling an argument object (`args`; see [naming.md](./naming.md#naming-the-args-object))
+is only necessary **when you need to fill in unrelated required arguments with neutral
+values** (i.e. when the properties of the argument passed exceed those in `input`). If
+the properties of the argument passed to the target under test (constructor / method)
+**match `input` exactly, with nothing missing or extra**, pass `input` directly rather
+than reassigning it into `args`.
+
+- Do not create an intermediate variable like `const args = { source: input.source }`
+  that just maps `input` 1:1 (it's redundant and duplicates management with `input`).
+- Only assemble `args` when there is something to fill in, mixing `input`'s values with
+  defaults.
+
+```js
+// Good: the argument matches input, so pass input directly
+test.each(cases)('source: $input.source', ({ input, expected }) => {
+  const received = BasicAuthorizationBuilder.generateCredential(input)
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+```js
+// Avoid: creating args that just copy input
+test.each(cases)('source: $input.source', ({ input, expected }) => {
+  const args = {
+    source: input.source,
+  }
+
+  const received = BasicAuthorizationBuilder.generateCredential(args)
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+```js
+describe('#scheme', () => {
+  const cases = [
+    {
+      input: { scheme: 'Bearer' },
+      expected: 'Bearer',
+    },
+    {
+      input: { scheme: 'Basic' },
+      expected: 'Basic',
+    },
+  ]
+
+  test.each(cases)('scheme: $input.scheme', ({ input, expected }) => {
+    const args = {
+      scheme: input.scheme,
+      credential: '', // Fill the unrelated required argument with a neutral value
+    }
+
+    const builder = new BaseAuthorizationBuilder(args)
+
+    expect(builder)
+      .toHaveProperty('scheme', expected)
+  })
+})
+```
+
+#### If `input` mixes properties and arguments, split into `args` (`constructorArgs` / `<methodName>Args`)
+
+If a single `input` contains **both a class's (constructor) property and an argument
+passed to the method under test**, you must **not** pass `input` as-is — splitting
+into an `args` per destination is **mandatory**. Name the variables per the convention
+in [naming.md](./naming.md#naming-the-args-object):
+**destination member name + `Args`** (the constructor's share is `constructorArgs`,
+the method's share is `<methodName>Args`). Do not use generic, role-based names like
+`propertyArgs` / `methodArgs`.
+
+- Do not pass the entirety of `input` directly to the constructor or method (mixing
+  properties and arguments makes it unreadable which one affects which).
+- Do not lump them into a single ambiguous `args` — split and name by destination
+  member (constructor → `constructorArgs`, `buildPathname()` → `buildPathnameArgs`; if
+  there is a third recipient, add `<memberName>Args` in the same way).
+- This is an exception to
+  ["If there is no addition/removal of properties, pass `input` as-is"](#if-there-is-no-additionremoval-of-properties-pass-input-as-is).
+  Since the destination splits into two or more, a direct pass is not possible.
+- Splitting and naming by member is about the case where **values mixed into a single
+  `input` need to be built separately for the constructor and for the method** (i.e.
+  when there are multiple builds). If a single build suffices, keep it as `args`
+  ([naming.md](./naming.md#naming-the-args-object)).
+- In a double loop, the outer = constructor property and the inner = method argument
+  usually have **separate sources**, so in most cases there is no need for multiple
+  builds. If the outer `input` matches the constructor 1:1, pass it **directly** as
+  `new SomeClass(input)`, and the only build needed is a single `args` for the inner
+  argument (no member-name split needed in this case). Only split by member name when
+  two or more builds are actually needed (e.g. the constructor side also needs
+  neutral-value filling and thus a build).
+- **If both the property and the argument are involved in the behavior, you must not
+  use a single loop.** Follow
+  [Constructor Property × Method Argument (double loop)](#constructor-property--method-argument-double-loop)
+  and lay out a 2×2 or larger grid with `describe.each()` × `test.each()`. A single
+  loop (pairing one property value with one argument value, one pair at a time) is
+  permitted only when **one axis is a neutral collaborator uninvolved in the
+  behavior** (e.g. only the target property is verified, and the method argument is
+  fixed at a neutral value).
+
+```js
+test.each(cases)('...', ({ input, expected }) => {
+  const constructorArgs = {
+    templatePathname: input.templatePathname,
+  }
+  const buildPathnameArgs = {
+    valueHash: input.valueHash,
+  }
+
+  const builder = new PathnameBuilder(constructorArgs)
+
+  const received = builder.buildPathname(buildPathnameArgs)
+
+  expect(received)
+    .toBe(expected)
+})
+```
+
+## Factory Method Tests
+
+For a factory method like `.create()`, test only the following:
+
+- That it returns an instance of its own class (`toBeInstanceOf`).
+- That it delegates to the constructor (verify `toHaveBeenCalledWith` via
+  `constructorSpy`).
+
+Do **not** test property retention. It is the constructor's responsibility, covered
+by the constructor's own tests — do not duplicate it here.
+
+### Verify default values on omitted arguments by "the default value reaching the constructor"
+
+When a factory fills in a default value for an omitted argument (e.g.
+`create ({ replacer = null } = {})`), split out `describe('should fill default <name>')`
+and verify — via `constructorSpy` — that the constructor is called with the default
+value when the factory is **called with no arguments**. Here too, do not look at the
+return value's properties (property retention is the constructor's responsibility).
+
+- When there is **only one** omittable argument, since the default value does not
+  depend on input, do not use `cases` / `test.each()` — place a single
+  `test('with no arguments')` (see the example below).
+- When there are **two or more** omittable arguments, a single `test()` is not enough.
+  Follow
+  [If there are multiple omittable arguments, run all combinations including omission (2ⁿ − 1)](#if-there-are-multiple-omittable-arguments-run-all-combinations-including-omission-2ⁿ--1).
+
+```js
+describe('should fill default replacer', () => {
+  test('with no arguments', () => {
+    const expected = {
+      replacer: null,
+    }
+
+    const SpyClass = constructorSpy.spyOn(BaseRequestBodyStringifier)
+
+    SpyClass.create()
+
+    expect(SpyClass.__spy__)
+      .toHaveBeenCalledWith(expected)
+  })
+})
+```
+
+### If there are multiple omittable arguments, run all combinations including omission (2ⁿ − 1)
+
+When there are **multiple** omittable arguments, the "call with no arguments" single
+`test()` above can verify only **one** case — omitting everything. That would miss
+coupling bugs where the default value of one argument "only takes effect when another
+argument is omitted/specified (or interferes with it)". To show that each argument's
+default-value filling takes effect **independently** of the others, vary each argument
+across the two states **specified (present) / omitted (absent)**, and turn **every
+combination in which at least one is omitted** into `cases`. **The single case where
+everything is specified fills in no default values at all**, so exclude it (that is
+covered by the delegation test in the "should call constructor" section above). With
+**n** arguments, there are **2ⁿ − 1** cases (with 3, as in
+`create ({ a = null, b = null, c = false })`, that's **7**).
+
+- A single `test('with no arguments')` suffices only when there is **one** omittable
+  argument. With **two or more**, enumerate 2ⁿ − 1.
+- Do not name the `describe()` after an individual argument — name it after
+  default-value filling **as a whole**, as in
+  `describe('should fill default value')`.
+- Put **only the arguments being specified** into `input`; for omitted arguments,
+  **comment them out** — the same technique as
+  [making missing properties explicit](#separate-valid--invalid-values) — leaving
+  behind the intent "this falls back to the default."
+- Write `expected` as the **complete shape** that reaches the constructor (specified
+  arguments keep their value, omitted arguments take the default), and verify it with
+  `constructorSpy`'s `toHaveBeenCalledWith(expected)`.
+- Give specified arguments values that are **unique and different from the default**
+  (if the value matches the default, you would miss a bug where a specified value is
+  ignored in favor of the default). Since each argument only has the two states
+  present/absent, the values themselves will **inevitably repeat** across combinations
+  (the uniqueness convention in [test-cases.md](./test-cases.md) does not apply here —
+  what identifies a case is not the value but the **combination**).
+- Since `input` is sparse, name the `test.each()` titles by **each value in
+  `expected`**.
+- Order per [list valid values first](./test-cases.md#list-normal-values-first): put cases with
+  **more items specified (present) first**, and put the **all-omitted (`input: {}`)** case last.
+  All-omitted is the most trivial edge case, so it does not go first (reducing from 2 specified →
+  1 → 0 reads more naturally).
+
+```js
+describe('SomeClass', () => {
+  describe('.create()', () => {
+    describe('should fill default value', () => {
+      const cases = [
+        {
+          input: {
+            alpha: 100001,
+            beta: 100002,
+            // gamma: omitted → default null
+          },
+          expected: {
+            alpha: 100001,
+            beta: 100002,
+            gamma: null,
+          },
+        },
+        // ... the remaining 2 combinations with 2 specified, then 3 with 1 specified, continuing as the specified count decreases
+        {
+          input: {
+            // alpha: omitted → default null
+            // beta: omitted → default null
+            gamma: 100003,
+          },
+          expected: {
+            alpha: null,
+            beta: null,
+            gamma: 100003,
+          },
+        },
+        {
+          input: {
+            // alpha: omitted → default null
+            // beta: omitted → default null
+            // gamma: omitted → default null
+          },
+          expected: { // all-omitted is an edge case, so it goes last
+            alpha: null,
+            beta: null,
+            gamma: null,
+          },
+        },
+        // 2³ − 1 = 7 combinations (all-specified is excluded since it fills no defaults; covered by should call constructor)
+      ]
+
+      test.each(cases)('alpha: $expected.alpha, beta: $expected.beta, gamma: $expected.gamma', ({ input, expected }) => {
+        const SpyClass = constructorSpy.spyOn(SomeClass)
+
+        SpyClass.create(input)
+
+        expect(SpyClass.__spy__)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})
+```
+
+## Separate Valid / Invalid Values
+
+When testing a method, if the argument values include a mix of **valid values (normal
+values)** and **invalid values (abnormal values)**, separate them with two
+`describe()`s to make the intent clear.
+
+- Valid values: the value is valid and is processed as expected (e.g. a placeholder
+  gets interpolated).
+- Invalid values: the value is invalid and falls back (e.g. a missing key, `null`, or
+  `undefined` becomes an empty string).
+- Do not mix both into a single `describe()` (or `cases` / `~Cases`).
+- For a case representing "a missing property", leave the missing property **commented
+  out** to make explicit what is being omitted (do not simply leave it out silently).
+
+```js
+// Make the missing property explicit
+{
+  valueHash: {
+    postId: 10,
+    // commentId: 20,
+  },
+  expected: '/posts/10/comments/',
+}
+```
+
+```js
+describe('#buildPathname()', () => {
+  describe('with valid values', () => {
+    // Only valid values that get interpolated
+  })
+
+  describe('with invalid values', () => {
+    // Only invalid values that fall back to an empty string
+  })
+})
+```
+
+## Split out recursive / nested structures into a dedicated `describe()`
+
+If a member processes a **recursive (self-nesting) structure** (a definition
+containing sub-definitions, a tree structure, an array/object nesting further
+arrays/objects, etc.), **split the recursive (nested) case out into a dedicated
+`describe()`** and verify it explicitly. Do not settle for flat (single-level) input
+alone.
+
+- **Why**: With only single-level input, it would still pass even if the
+  implementation **does not actually recurse into the nesting and instead flattens it
+  shallowly**. Verifying that recursion actually takes effect (each nested layer is
+  processed correctly) requires input nested **at least two levels deep** (the QA
+  stance in [SKILL.md](../SKILL.md)).
+- Name the dedicated describe to indicate recursion (e.g. `describe('with nested ...')`
+  / `describe('when nested')`). Since this is an axis **independent of** the
+  valid/invalid split, do not mix it into the same describe as the flat cases — split
+  it out for recursion to make the intent stand out.
+- For recursive cases, pin the fact that the **output is also nested** via the nested
+  structure of `expected` (use a value that would not match a shallow flattening). A
+  depth of two levels is usually sufficient, but if there are variations of nesting
+  (an array within an array vs. an array within an object, etc.), place several
+  representative cases.
+
+```js
+describe('SomeClass', () => {
+  describe('#normalize()', () => {
+    describe('with valid values', () => {
+      // Flat (single-level) input
+    })
+
+    describe('with nested values', () => { // Split out recursion
+      const cases = [
+        {
+          input: {
+            value: {
+              child: {
+                id: 100001,
+              },
+            },
+          },
+          expected: {
+            child: {
+              id: 100001,
+            },
+          },
+        },
+        // ... other nesting shapes (an array within an object, an array of arrays, ...)
+      ]
+
+      test.each(cases)('value: $input.value', ({ input, expected }) => {
+        const received = SomeClass.create(input).normalize()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+```
+
+## Boolean-like methods (separating truthy / falsy)
+
+For a method whose return value is boolean (or can be judged as truthy / falsy), do
+not lump it into a single `cases` with `expected: true / false`. Instead, separate it
+with `describe('should be truthy')` / `describe('should be falsy')`, and within each
+describe, **omit `expected`** and fix the assertion to `toBeTruthy()` / `toBeFalsy()`.
+
+- Which result is being verified is made explicit by the describe name, making the
+  intent easier to read.
+- `expected` becomes unnecessary, so `cases` only needs `input` (or `~Cases`).
+
+```js
+describe('#isValid()', () => {
+  describe('should be truthy', () => {
+    const cases = [
+      { input: { value: 100001 } },
+      { input: { value: 100002 } },
+    ]
+
+    test.each(cases)('value: $input.value', ({ input }) => {
+      const instance = SomeClass.create(input)
+
+      const received = instance.isValid()
+
+      expect(received)
+        .toBeTruthy()
+    })
+  })
+
+  describe('should be falsy', () => {
+    const cases = [
+      { input: { value: null } },
+      { input: { value: undefined } },
+    ]
+
+    test.each(cases)('value: $input.value', ({ input }) => {
+      const instance = SomeClass.create(input)
+
+      const received = instance.isValid()
+
+      expect(received)
+        .toBeFalsy()
+    })
+  })
+})
+```
+
+## Methods that memoize and return the same reference (`should be memoized`)
+
+For a method that, when called multiple times with the same argument, returns the
+**same instance (same reference)** (memoization, caching, pooling — e.g. storing in a
+`WeakMap` and returning the stored value from the second call onward), verify that "the
+same reference is returned every time." Express the behavior layer with
+`describe('should be memoized')`.
+
+- **Bind the first call's return value to `expected` in Arrange**, and treat the second
+  call's return value as `received` (Act), verifying **the same reference** with
+  `toBe(expected)`. Append `// same reference` at the end of the assertion line (per
+  the same-reference comment convention in [aaa-pattern.md](./aaa-pattern.md)).
+- Even when the expected value is generated at runtime (the result of the first call),
+  since it is "the value we expect," **bind it to `expected`** (do not use an alias
+  such as `first` / `initial`). This lets you express the comparison of two calls
+  while still satisfying [aaa-pattern.md](./aaa-pattern.md)'s rule that "only
+  `expected` and `tally` may be passed to the matcher."
+- There is no static expected-value literal, so `cases` only needs **`input`**. Place
+  several cases with varying arguments to show that memoization takes effect for any
+  key.
+- "What is returned" (a `WeakMap`, an instance, etc.) is pinned earlier, in a separate
+  behavior from memoization (e.g. `describe('should be a WeakMap')`), using
+  `toBeInstanceOf()`. Do not mix the type check and the memoization check into a single
+  test.
+
+```js
+describe('BoundCtorRegistry', () => {
+  describe('.ensureCtorPool()', () => {
+    describe('should be a WeakMap', () => {
+      const cases = [
+        {
+          input: {
+            weakMapKey: { id: 100001 },
+          },
+        },
+        {
+          input: {
+            weakMapKey: { id: 100002 },
+          },
+        },
+      ]
+
+      test.each(cases)('weakMapKey: $input.weakMapKey', ({ input }) => {
+        const received = BoundCtorRegistry.ensureCtorPool(input)
+
+        expect(received)
+          .toBeInstanceOf(WeakMap)
+      })
+    })
+
+    describe('should be memoized', () => {
+      const cases = [
+        {
+          input: {
+            weakMapKey: { id: 100003 },
+          },
+        },
+        {
+          input: {
+            weakMapKey: { id: 100004 },
+          },
+        },
+      ]
+
+      test.each(cases)('weakMapKey: $input.weakMapKey', ({ input }) => {
+        const expected = BoundCtorRegistry.ensureCtorPool(input) // 1st call = memoized reference
+
+        const received = BoundCtorRegistry.ensureCtorPool(input) // 2nd call
+
+        expect(received)
+          .toBe(expected) // Same reference
+      })
+    })
+  })
+})
+```
+
+### For shared static state (a pool), use a fresh key per case
+
+When the memoization container is a **static property** (e.g.
+`static pool = new WeakMap()`), that state **persists across tests** (`afterEach`'s
+`jest.restoreAllMocks()` only restores spies — it does not reset the contents of a
+static `WeakMap`). To avoid cross-contamination between cases and between tests, use a
+**fresh object reference per case** as the key (e.g. `{ id: 100001 }`). Since a
+`WeakMap` distinguishes keys by object reference, a different reference means a
+different entry, so there is no interference.
+
+## Single loop
+
+When there is **no combination** between constructor properties and method arguments,
+use a single loop (a single tier of `test.each`). Gather the required arguments into
+one `input`.
+
+```js
+describe('PathnameBuilder', () => {
+  describe('#buildPathname()', () => {
+    describe('should interpolate placeholder', () => {
+      const cases = [
+        {
+          input: {
+            valueHash: { id: 123 },
+          },
+          expected: '/users/123',
+        },
+      ]
+
+      test.each(cases)('valueHash: $input.valueHash', ({ input, expected }) => {
+        const builder = PathnameBuilder.create({ templatePathname: '/users/[id]' })
+
+        const received = builder.buildPathname(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+```
+
+## Constructor Property × Method Argument (double loop)
+
+When a member takes both a **constructor property** and a **method argument**, and
+**both** are involved in the output (including behaviors like memoization), **default
+to this double loop**. Combine `describe.each()` (outer = constructor property) with
+`test.each()` (inner = method argument). A member such as
+`#ensureBoundCtor({ bindings, deriver })` (property `BaseCtor` × argument `bindings`)
+fits this.
+
+- **Do not lay out a single loop pairing "one property value × one argument value" one
+  pair at a time.** That fails to verify that each axis independently affects the
+  behavior, and invites false positives (it would still pass with one side held
+  fixed). For the same reason as
+  [when multiple properties are involved in the output](#when-multiple-properties-are-involved-in-the-output-property--property),
+  lay out **at least 2×2** (2 or more values per axis).
+- The exception is when **one axis is "a neutral collaborator not under test."** If an
+  argument must be passed but does not affect the behavior (i.e. only one side is
+  involved in the output), it is fine to use a single loop and fix the other side at a
+  neutral value. For the `constructorArgs` / `<methodName>Args` split in that case, see
+  [If `input` mixes properties and arguments, split into `args`](#if-input-mixes-properties-and-arguments-split-into-args-constructorargs--methodnameargs).
+  Fix a value as neutral only when you can say **the contract guarantees that axis
+  does not affect the behavior** — not because "reading the implementation shows it
+  has no effect, so I'll use a single loop" (the QA principle in
+  [SKILL.md](../SKILL.md)).
+- Each element of the outer `cases` **bundles together** `input` (the constructor
+  property) with its own dedicated inner cases (`~Cases`).
+- For the naming convention of the inner cases variable (the prefixed `~Cases`), see
+  [naming.md](./naming.md).
+- Use `override` / `input` / `tally` on the **outer** element side. `expected` may be
+  placed on the **inner** side if its value **varies per inner argument**, or on the
+  **outer** side if it is **constant per outer property** (the only reserved property
+  allowed in the inner `~Cases` is `expected`).
+
+```js
+describe('SomeClass', () => {
+  describe('#someMethod()', () => {
+    const cases = [
+      {
+        input: {
+          alpha: 1,
+        },
+        betaCases: [
+          {
+            beta: 10,
+            expected: 9,
+          },
+          {
+            beta: 20,
+            expected: 19,
+          },
+        ],
+      },
+      {
+        input: {
+          alpha: 2,
+        },
+        betaCases: [
+          {
+            beta: 20,
+            expected: 18,
+          },
+          {
+            beta: 30,
+            expected: 28,
+          },
+        ],
+      },
+    ]
+
+    describe.each(cases)('alpha: $input.alpha', ({ input, betaCases }) => {
+      test.each(betaCases)('beta: $beta', ({ beta, expected }) => {
+        const instance = SomeClass.create(input)
+
+        const received = instance.someMethod({ beta })
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+```
+
+### Placement within a `describe.each()` callback (what may go before `test.each()`)
+
+Inside a `describe.each()` callback, the following may be placed **before**
+`test.each()`.
+
+1. **Variables that can be built without using the inner `~Cases` values** (e.g. an
+   instance built only from the outer `input`) go before `test.each()`. Only things
+   that depend on the inner value (such as the `args` argument) go inside
+   `test.each()`. This lets the same variable be shared across all inner tests,
+   reducing duplication. This **applies equally to a single `test.each()`**: any
+   variable that does not depend on the per-case value the callback receives (`input`
+   / `expected`, etc.) should be defined once, outside `test.each()`. If `args` is
+   **case-invariant** (buildable from fixed fixtures alone), pull it outside the
+   callback rather than rebuilding it inside
+   ([aaa-pattern.md](./aaa-pattern.md#assemble-method-arguments-in-arrange-and-pass-a-variable-in-act)).
+2. When placing statements such as assignments before `test.each()`, insert **a blank
+   line** between them and `test.each()` (to make the boundary between setup and
+   iteration explicit).
+3. If the inner `~Cases` passed to `test.each()` is **the same across every
+   `describe.each()` case**, you can define it **once, right before `test.each()`**,
+   rather than bundling it into each element of the outer `cases` (the outer can then
+   focus purely on `input` / `expected`, eliminating duplication of the inner data).
+   If the inner cases differ per case, bundle `~Cases` into the outer elements as
+   before.
+
+If `expected` is **constant per outer property** (unchanged even as the inner argument
+varies), place `expected` on the outer element, and let the inner `~Cases` hold only
+the arguments. Below is an example applying (1)(2)(3) above to the verification that
+`#ensureBoundCtor()` "derives from `BaseCtor`". The derivation source is determined by
+`BaseCtor` (outer), and does not change even as `bindings` (inner) varies. Hence
+`expected` is placed on the outer; `bindingsCases`, being the same across every
+`BaseCtor`, is defined right before `test.each()`; and `registry`, buildable from
+`input` alone, is placed before `test.each()`.
+
+```js
+describe('BoundCtorRegistry', () => {
+  describe('#ensureBoundCtor()', () => {
+    /**
+     * @param {{ Ctor: new () => * }} params
+     * @returns {new () => *}
+     */
+    const deriver = ({ Ctor }) => class extends Ctor {}
+
+    describe('should be derived from base constructor', () => {
+      const cases = [
+        {
+          input: {
+            BaseCtor: AlphaBaseCtor,
+          },
+          expected: AlphaBaseCtor, // Constant regardless of the inner bindings → placed on the outer
+        },
+        // ... an element for BetaBaseCtor follows
+      ]
+
+      describe.each(cases)('BaseCtor: $input.BaseCtor.name', ({ input, expected }) => {
+        const registry = new BoundCtorRegistry(input) // (1) buildable from input alone → before test.each()
+
+        const bindingsCases = [ // (3) the same across every BaseCtor → defined once, right before
+          {
+            bindings: [
+              { id: 100001 },
+            ],
+          },
+          {
+            bindings: [
+              { id: 100002 },
+            ],
+          },
+        ] // (2) separated from test.each() by the blank line that follows
+
+        test.each(bindingsCases)('bindings: $bindings', ({ bindings }) => {
+          const args = {
+            bindings, // Depends on the inner value, so assembled inside test.each()
+            deriver,
+          }
+
+          const BoundCtor = registry.ensureBoundCtor(args)
+          const received = BoundCtor.prototype
+
+          expect(received)
+            .toBeInstanceOf(expected)
+        })
+      })
+    })
+  })
+})
+```
+
+## When multiple properties are involved in the output (property × property)
+
+When a method's (or getter's) output involves **two or more properties**, test their
+**combinations** with a double loop of `describe.each()` (outer = one property) ×
+`test.each()` (inner = the other property). To confirm each property independently
+affects the output, write **at least 2 × 2 = 4 cases** (2 or more values per
+property).
+
+- Do not use a single loop varying only one property. Fixing one side makes it
+  impossible to confirm whether the other side contributes to the output (this
+  invites false positives).
+- The variable naming and inner cases (`~Cases`) conventions are the same as in
+  [Constructor Property × Method Argument](#constructor-property--method-argument-double-loop).
+- Keep primitive values **unique** across all 4 cases ([test-cases.md](./test-cases.md)).
+
+```js
+describe('BaseAuthorizationBuilder', () => {
+  describe('#generateHeaderValue()', () => {
+    describe('should join scheme and credential', () => {
+      const cases = [
+        {
+          input: { scheme: 'Bearer' },
+          credentialCases: [
+            {
+              credential: 'credential-0001',
+              expected: 'Bearer credential-0001',
+            },
+            {
+              credential: 'credential-0002',
+              expected: 'Bearer credential-0002',
+            },
+          ],
+        },
+        {
+          input: { scheme: 'Basic' },
+          credentialCases: [
+            {
+              credential: 'credential-0003',
+              expected: 'Basic credential-0003',
+            },
+            {
+              credential: 'credential-0004',
+              expected: 'Basic credential-0004',
+            },
+          ],
+        },
+      ]
+
+      describe.each(cases)('scheme: $input.scheme', ({ input, credentialCases }) => {
+        test.each(credentialCases)('credential: $credential', ({ credential, expected }) => {
+          const builder = new BaseAuthorizationBuilder({
+            scheme: input.scheme,
+            credential,
+          })
+
+          const received = builder.generateHeaderValue()
+
+          expect(received)
+            .toBe(expected)
+        })
+      })
+    })
+  })
+})
+```
+
+## Separate mutually-interacting arguments with `describe()`
+
+When a method has two or more arguments and **one changes how the other is
+interpreted or behaves** (a mode / flag / strategy — not independent, but
+**interacting**), **split by the value of the mode-like argument, using
+`describe()`**. The standard form is `describe('with <arg>: <value>')`. Fix the mode
+argument within each describe and vary the remaining arguments.
+
+- If the two axes affect the output independently, the
+  [double loop](#constructor-property--method-argument-double-loop) grid suffices. But if
+  **one conditions the other** (a flag changes the processing path itself), splitting
+  by describe per path reads better.
+- Why split: mixing modes into a single `cases` makes it hard to trace which mode each
+  case verifies, and makes it hard to confirm coverage per mode (whether the same
+  input range was tried under each mode). Splitting by describe makes the mode
+  explicit by name, and coverage within each mode is visible at a glance.
+- Inside the mode describe, the remaining axis may be driven using the existing
+  conventions ([Constructor Property × Method Argument](#constructor-property--method-argument-double-loop)
+  / [when multiple properties are involved in the output](#when-multiple-properties-are-involved-in-the-output-property--property)
+  / an axis × count grid, etc.).
+- Since the mode argument becomes a fixed value within each describe, **omit** it from
+  the `cases` elements and write it directly into `args` in the `test` body (e.g.
+  `mode: true`).
+
+```js
+describe('SomeClass', () => {
+  describe('#run()', () => {
+    describe('with mode: true', () => {
+      const cases = [
+        {
+          input: {
+            value: 'alpha',
+          },
+          expected: '...',
+        },
+        // ... the input range when mode is true
+      ]
+
+      test.each(cases)('value: $input.value', ({ input, expected }) => {
+        const args = {
+          value: input.value,
+          mode: true, // mode is fixed by the describe → written directly into args
+        }
+
+        const received = SomeClass.create().run(args)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('with mode: false', () => {
+      // Run the same input range with mode: false (the path changes, so expected changes too)
+    })
+  })
+})
+```
+
+## Separate boolean arguments/properties with `describe()`
+
+For a **boolean argument or property** that the target under test receives (a true/false
+flag such as `isEnabled`), do not fold it into `cases`'s `input` — instead, **separate
+by `describe()` per value** (`describe('when #isEnabled:false')` /
+`describe('when #isEnabled:true')`). Since a boolean only takes two possible values,
+splitting by describe is easy, and once split, each `cases`'s `input` / `expected` can
+**focus purely on the other axis**, making it simpler.
+
+- This is the classic case of [Separate mutually-interacting arguments with
+  `describe()`](#separate-mutually-interacting-arguments-with-describe). Since the boolean value is fixed per
+  describe, **omit** it from the `cases` elements and write it directly into `args` in the `test` body (e.g.
+  `isEnabled: false`). Leave `input` holding **only the other axis's value**.
+- When coexisting with another describe layer (such as the valid/invalid split), put
+  the **boolean describe on the inside**
+  (`describe('with valid values') > describe('when #isEnabled:false')`). Valid/invalid
+  reflects the nature of the input value, while a boolean flag is a mode — so split by
+  the nature of the value first, and vary the mode within it.
+- The label is `when <flag>:<value>`. If the flag is an **instance property** (one
+  that exists as `this.<flag>`, such as `isNullable`), prefix it with **`#`** per the
+  member notation (`when #isNullable:true`). A pure method-argument flag that is not
+  turned into a property (e.g. `mode`) uses the bare name (`when mode:true`). The
+  `args` key and `this.<flag>` remain in their bare form — `#` appears only in the
+  describe label's notation (the same as `#method()`).
+- Even when a boolean flag **changes the very determination of valid/invalid** (e.g.
+  under `#isEnabled:true`, a value that was previously invalid becomes valid, or only
+  the null guard remains), place inside each mode's `describe()` only the results that
+  actually occur under that mode (do not include, say, borrowed values that throw,
+  per the policy in [test-cases.md](./test-cases.md)).
+
+```js
+describe('SomeClass', () => {
+  describe('#someMethod()', () => {
+    describe('with valid values', () => {
+      describe('when #isEnabled:false', () => {
+        const cases = [
+          {
+            input: {
+              value: 'alpha-0001',
+            },
+            expected: 'alpha-0001',
+          },
+          // ...
+        ]
+
+        test.each(cases)('value: $input.value', ({ input, expected }) => {
+          const args = {
+            value: input.value,
+            isEnabled: false, // The boolean flag is fixed per describe → folded into args, not into cases
+          }
+          const instance = SomeClass.create(args)
+
+          const received = instance.someMethod()
+
+          expect(received)
+            .toBe(expected)
+        })
+      })
+
+      describe('when #isEnabled:true', () => {
+        // Same shape with isEnabled: true. input holds only the value axis
+      })
+    })
+
+    describe('with invalid values', () => {
+      // describe('when #isEnabled:false') / describe('when #isEnabled:true') likewise
+    })
+  })
+})
+```
+
+## For a member that may depend on a property, split `describe()` by that property axis to show (in)dependence too
+
+When a member's output **may depend** on a class property such as `#isNullable`,
+verify it by splitting on that property axis with `describe('when #isNullable:false')`
+/ `describe('when #isNullable:true')`. Even when it **does not depend** on it (an
+override ignores it and always returns the same result), **do not omit this** — only
+by verifying that both modes produce the same result can you guarantee the contract
+that this member is **independent** of the property (if you skip it based on
+implementation knowledge — "it shouldn't have an effect" — you would fail to notice if
+it accidentally regresses into depending on the property; the QA stance in
+[SKILL.md](../SKILL.md)).
+
+- This is an application of
+  [Separate boolean arguments/properties with `describe()`](#separate-boolean-argumentsproperties-with-describe).
+  The only difference is that a **dependent** member (e.g. `#normalizeValue()`
+  changing its result based on `#isNullable`) produces **different** results per mode,
+  while an **independent** member (e.g. `#hasAvailableNormalizedValue()` below)
+  produces the **same** result per mode — but both split by the property axis with
+  `describe()`.
+- When coexisting with another describe layer (`should be truthy` / valid-invalid,
+  etc.), the property describe goes **on the inside**
+  (`describe('should be truthy') > describe('when #isNullable:false')`).
+- Since the label refers to an instance property, prefix it with `#`
+  (`when #isNullable:true`). Fix the property value per describe and write it into the
+  `test` body's `args` (e.g. `isNullable: false` — no `#` prefix there).
+- Even for an independent member, including a value the base class treats specially
+  (e.g. `null`) on the value side of the cases lets you demonstrate independence from
+  **both** the property and the value at once.
+
+```js
+// SomeClass#isAvailable() ignores #isNullable and always returns available.
+// It is still split by #isNullable, and both modes are verified to return the same truthy, showing independence.
+describe('SomeClass', () => {
+  describe('#isAvailable()', () => {
+    describe('should be truthy', () => {
+      describe('when #isNullable:false', () => {
+        const cases = [
+          {
+            input: {
+              value: 100001,
+            },
+          },
+          {
+            input: {
+              value: null, // The base class treats null as unavailable, but this override returns available
+            },
+          },
+        ]
+
+        test.each(cases)('value: $input.value', ({ input }) => {
+          const args = {
+            value: input.value,
+            isNullable: false,
+          }
+          const received = SomeClass.create(args).isAvailable()
+
+          expect(received)
+            .toBeTruthy()
+        })
+      })
+
+      describe('when #isNullable:true', () => {
+        // Same value cases with isNullable: true. Still all truthy
+      })
+    })
+  })
+})
+```

--- a/kit/skills/core/hc-jest/references/test-cases.md
+++ b/kit/skills/core/hc-jest/references/test-cases.md
@@ -1,0 +1,578 @@
+# Test Cases (data convention for cases)
+
+Convention for how to build the data for `cases` in Jest. Referenced from
+`SKILL.md`. See [naming.md](./naming.md) for variable/property naming, and
+[structure.md](./structure.md) for loop structure (single/double).
+
+Each behavior defines `const cases = [ ... ]` and runs it with `test.each(cases)`.
+
+- Every element of `cases` must be **an object** (never place a primitive directly).
+- See [naming.md](./naming.md) for the top-level property names of element
+  objects (`override` / `input` / `tally` / `expected`, and the `~Cases`
+  exception for the outer loop of a double loop), and for the variable naming
+  of `cases` / `~Cases`.
+- In principle, `cases` (and the inner `~Cases`) should contain **2 or more**
+  elements. A single element is acceptable only when there is a specific
+  reason, such as when only one case can be truthy.
+- Unnecessary properties may be omitted (not all 4 are mandatory).
+- Unless there is a specific reason not to, primitive values that appear in
+  `cases` should be **unique across elements** (don't reuse the same value
+  across multiple cases).
+
+  **Why**: This is to confirm that "the value given as `input` is correctly
+  reflected in `expected`." If values are duplicated, the test can pass by
+  coincidence **even if the implementation returns a different input's value**
+  (a false positive). Making values unique guarantees that the input-to-output
+  correspondence is actually being exercised.
+- For values like `id`, make sure the **element index** within the array can
+  be read off from Jest's console log. Specifically, use values like
+  `100001`, `100002`, `100003`, … where **the last digit (the index) stands
+  out as a large value** (`index` is counted per array). This lets you
+  immediately identify which case a value in the log corresponds to.
+  - Numeric `id`s should be **at least 6 digits** (`100001` or higher). Fixing
+    the digit count aligns the position of the last-digit index across all
+    cases, keeping visibility consistent. Do not use small values like `id: 1`.
+- For strings, similarly attach a **base string + index suffix**, like
+  `'alpha-0001'`, `'alpha-0002'`, …, so the index can be read off.
+  - Keep the base string **consistent across elements** (`'source-0001'`,
+    `'source-0002'`, `'source-0003'`). Do not change the base per element
+    (`'alpha:0001'` / `'beta:0002'`), and do not use a separator other than `-`.
+  - Even if you're tempted to use a domain-plausible-looking value (e.g. an
+    input that resembles Basic auth like `'username:password'`), do not break
+    this format. Prioritize keeping the index readable.
+- When `expected` is an **opaque value derived from the input** (Base64, hash,
+  signature, etc. — a value that cannot embed a readable index), have the
+  **`input` side** carry the index instead. `expected` is written as the raw
+  derived result (it need not carry an index). Since `input`'s value appears
+  in the log, the case can be identified from there.
+
+```js
+// expected is Base64 (opaque), so input.source carries the index
+const cases = [
+  {
+    input: { source: 'source-0001' },
+    expected: 'c291cmNlLTAwMDE=',
+  },
+  {
+    input: { source: 'source-0002' },
+    expected: 'c291cmNlLTAwMDI=',
+  },
+]
+```
+
+### Write derived values and magic constants as literals, with the derivation expression added as a comment
+
+When writing boundary values or derived constants — **literals whose meaning
+cannot be read off from the value itself** (a large integer beyond
+`Number.MAX_SAFE_INTEGER`, a boundary value at a specific digit count, etc.)
+— into `cases`, write the value **directly as a literal**, and attach its
+**derivation expression** as a `// <expression>` comment. This keeps the case
+data static and diff-friendly, while letting the reader (or a future editor)
+understand "why this value — i.e., what it was derived from" without having
+to recompute it.
+
+- Write the value in **the actual type of that field** (a string literal for
+  a string field). Do **not compute inline** with an expression (keep the
+  case data as a literal, and show the derivation via an expression comment).
+- Write the derivation expression in the comment as **readable plain
+  arithmetic** (e.g. `Number.MAX_SAFE_INTEGER + 2`). Since the literal itself
+  already fixes the exact value and type, there's no need to wrap the comment
+  in `BigInt(...)` or append `2n` to make it "match exactly if executed" (the
+  comment is an annotation showing the meaning of the value, not executable
+  code). In fact, it's precisely because `Number` arithmetic would round and
+  fail to match exactly (as with the string representation of a `bigint`)
+  that you should avoid inline computation and instead use a literal plus a
+  derivation-expression comment.
+
+```js
+const cases = [
+  {
+    input: {
+      value: '9007199254740993', // Number.MAX_SAFE_INTEGER + 2
+    },
+    expected: 9007199254740993n, // Number.MAX_SAFE_INTEGER + 2
+  },
+]
+```
+
+### For opaque-value titles too, first use a readable identifying property (`$#` is a last resort)
+
+Even when the test target handles **opaque objects** (types like `WeakMap` /
+`Map` / `Set` / instances, whose console output collapses to something like
+`WeakMap {}`), do not **casually reach for `$#`** (Jest's row index, i.e. a
+serial number). The number only conveys "which position," not "what is
+different about this case."
+
+- First, look for **a meaningfully different value** across cases. Even for
+  objects/instances, if there is an attribute that distinguishes the cases
+  (a config value, a kind, a key, etc.), display it via a key path like
+  `$input.<field>.<prop>`. For example, if the difference is in a config
+  value of an instance, write
+  `test.each(cases)('<prop>: $input.<field>.<prop>', ...)`.
+- Using `$#` is acceptable **only** when the value has **no readable
+  identifier to begin with** (the contents collapse and there's no way to
+  distinguish them, e.g. two empty `WeakMap`s). Even then, do **not fabricate**
+  a readable index (don't invent `{ id: 1 }`, `{ id: 2 }` and distort the type).
+- Even when the argument type is opaque, **pass a real instance matching the
+  declared type** ("prepare a real value matching the declared type" in
+  [types.md](./types.md)). Don't substitute `{ id: 100001 }` and paper over
+  the type with `/** @type {*} */`; pass the real thing, like `new WeakMap()`.
+
+```js
+// No distinguishable readable property exists (two empty WeakMaps) -> use $# as a last resort
+describe('.ensureCtorPool()', () => {
+  describe('should be a WeakMap', () => {
+    const cases = [
+      {
+        input: {
+          weakMapKey: new WeakMap(), // real instance; { id: ... } would not satisfy the type
+        },
+      },
+      {
+        input: {
+          weakMapKey: new WeakMap(),
+        },
+      },
+    ]
+
+    test.each(cases)('weakMapKey: $#', ({ input }) => { // no distinguishable value, so use the index
+      const received = BoundCtorRegistry.ensureCtorPool(input)
+
+      expect(received)
+        .toBeInstanceOf(WeakMap)
+    })
+  })
+})
+```
+
+```js
+// Even for opaque instances, if there is an attribute that distinguishes the cases, display it (don't use $#)
+test.each(cases)('<prop>: $input.<field>.<prop>', ({ input, expected }) => {
+  // ...
+})
+```
+
+## When a sample string needs to be a "run of words," mechanically line up alpha, beta, … omega
+
+When a sample string needs to be **a run of words (tokens)** (words joined by
+a delimiter, a sequence of multiple tokens, i.e. cases where the index-suffix
+scheme above doesn't fit as a shape), assign **`alpha`, `beta`, `gamma`, …
+`omega`** to the word tokens **mechanically, in this order**. Picking real
+words at random (one element being `one_two_three`, the next
+`four_five_six`, the next `hotel_india_juliet`, …) has no pattern, and the
+reader can't track "which word, in which position, of which case." Using the
+Greek letters in order lets the reader grasp the sequence just by reading top
+to bottom.
+
+- For cases that need multiple tokens, consume `alpha` onward **in order
+  across the whole `cases`** (2 words → `alpha`/`beta`; if the next case
+  needs 3 words → `gamma`/`delta`/`epsilon` …).
+- When treating **just a single token as representative** (a placeholder
+  where the content doesn't matter and "some one word" is enough), use
+  **`omega`**. Do not use conventional names like `foo` / `bar`.
+- For values you want to identify by reading the index (a sequential `id`,
+  etc.), use the conventional `100001…` / `'source-0001'…` index-suffix
+  scheme (top of this file) as before, not Greek letters. The Greek-letter
+  scheme is only for strings that need to "look like a run of words."
+
+## Show intent for strings that carry meaning, either via the string itself or an English inline comment
+
+When a string value is used as **a value carrying a specific intent (role,
+kind)** (not just an indexed placeholder, but a case where you're **giving
+meaning** to the string, such as "a value that is not a constructor" or "an
+unparseable date string"), supplement that intent **in English**, via one
+of the following:
+
+- **Make the string itself descriptive**: make the value such that reading it
+  reveals the role (e.g. `'not-a-constructor'` / `'unparseable-date'`). Don't
+  leave it as a meaningless indexed value like `'text-0001'`.
+- **Add an English inline comment**: when the value itself cannot be made
+  descriptive (or you don't want to change it), supplement the role with
+  `// ...`.
+
+- Indexed placeholders (`'text-0001'` / `'source-0002'`) and Greek-letter
+  tokens (`alpha` / `omega`) are used for "a representative value whose
+  content doesn't matter," which is a separate concern from this convention.
+  Only for strings you want to **carry specific meaning**, show the intent
+  through a descriptive value or a comment.
+- Comments should be written in English, per "Write comments in the code in
+  English" in [SKILL.md](../SKILL.md).
+
+```js
+// Good: the string itself conveys the role
+const cases = [
+  {
+    input: {
+      handler: 'not-a-function', // verifies the fallback for a non-function value
+    },
+  },
+]
+
+// Good: when the value itself can't show it, supplement the intent with an English inline comment
+const cases = [
+  {
+    input: {
+      value: 'text_0001', // an unparseable date string (a hyphen would be parsed as a year)
+    },
+  },
+]
+```
+
+## If the set of possible values is finite and small, write out all cases
+
+If the possible inputs (or branches) of a member are **finite** and
+**small in number** (a range a human can hold in memory), don't sample
+representative values — **enumerate all cases**. The criterion for "small" is
+**"whether a human can memorize it."** As a rule of thumb, up to roughly
+**100 cases** counts as "all cases."
+
+- Examples of finite and small: the set of special characters requiring
+  regex-escaping, enums, boolean combinations, days of the week, HTTP
+  methods, and other domains that **can be exhaustively enumerated**. If you
+  sample only representative values from these, a broken branch for an
+  omitted value would go unnoticed.
+- Infinite/large inputs (arbitrary strings, the full range of numbers, etc.)
+  cannot be exhaustively enumerated, so **sample** representative values plus
+  edge values as before ([list normal values first](#list-normal-values-first)).
+- Decision procedure: consider whether the set of values accepted by the
+  target member can be enumerated. If it can be enumerated and is small
+  enough for a human to memorize, write all cases; otherwise, sample.
+- Sampling only part of a finite set means a broken branch for an omitted
+  value would still pass the test. If there is a separate, paired infinite
+  set (e.g. "the enumerable target" vs. "everything else"), sample that one
+  with representative values instead.
+
+## Choose values that exercise the internal transformation (don't fill cases with no-op values only)
+
+When a member **doesn't use a property or argument as-is, but transforms it
+once internally** (escape / normalize / trim / encode / substitution, etc.),
+always include in the cases **a value for which the output would change if
+the transformation were not applied**. Testing only with values for which the
+transformation is a pass-through (no-op) means the test would still pass even
+if the transformation logic were broken or removed, failing to verify that
+the transformation exists at all (a concretization of the QA principle in
+[SKILL.md](../SKILL.md)).
+
+- Decision procedure: check whether, in the target member's code, the
+  property/argument is used "as-is" or processed once before use (passed
+  through another method, embedded into a regex, used as the target/
+  replacement of a substitution, etc.). If there is processing, include at
+  least one case with **a value for which the result changes depending on
+  whether that processing happened**.
+- Don't fill `cases` with **no-op values** only (values where the result is
+  the same whether or not the transformation is applied). It's fine to
+  include a no-op value as a typical case, but you must also add **at least
+  one value that actually exercises the transformation**.
+- Examples of "values that exercise the transformation," by transformation
+  kind:
+  - Escaping before embedding into a regex → **regex special characters**
+    (`.` `$` `*` `+` `?` `(` `)` `[` `]` `{` `}` `|` `\` `^`). If not escaped,
+    they misbehave as metacharacters.
+  - Trim / whitespace normalization → **values containing whitespace**
+    (leading/trailing or consecutive).
+  - Uppercasing / lowercasing → **values that originally contain the
+    opposite case**.
+  - Encoding (URL / Base64, etc.) → **values containing characters subject to
+    encoding**.
+
+### For a terminal method that performs the transformation, write all cases; for the caller, sample (at least one per path)
+
+Even for the same transformation, the granularity of verification varies by
+**where the member sits**.
+
+- **The terminal/helper method that implements the transformation** (the one
+  that holds the transformation logic itself): if the set of transformation
+  targets is finite and small, write **all cases**
+  ([If the set of possible values is finite and small, write out all cases](#if-the-set-of-possible-values-is-finite-and-small-write-out-all-cases)).
+  Since this is the final place that guarantees the correctness of the
+  transformation, leave no gaps here.
+- **The caller of the terminal method** (the side that internally calls the
+  terminal method and uses its result): exhaustive enumeration is unnecessary
+  (correctness is already guaranteed at the terminal). However, sample **at
+  least one value where the transformation takes effect, and at least one
+  no-op value**, respectively. This is to confirm that both paths are wired
+  correctly (i.e., that the value is actually routed through the terminal
+  before use) — with only one, a break in the other path would go unnoticed.
+
+## For features that handle integers, always test near the `Number.MAX_SAFE_INTEGER` threshold
+
+For tests of features that involve integers (integer scalars, integer
+validation, anything with a safe-integer check like `Number.isSafeInteger`),
+always include a case **near the `Number.MAX_SAFE_INTEGER` threshold**.
+JavaScript's `Number` can only safely represent integers up to `2 ** 53 - 1`
+(`Number.MAX_SAFE_INTEGER` = 9007199254740991), and this boundary is the most
+fragile and meaningful edge for integer features.
+
+- Place the boundary itself (`Number.MAX_SAFE_INTEGER`) on the **valid
+  (normal)** side, and one past the boundary
+  (`Number.MAX_SAFE_INTEGER + 1`) on the **invalid (not a safe integer)** side.
+- Don't hard-code a giant numeric literal for the value — use the
+  **expression `Number.MAX_SAFE_INTEGER` / `Number.MAX_SAFE_INTEGER + 1`**
+  directly as the value (readable, and no loss of precision. Since these are
+  known named constants, you can write the expression itself rather than the
+  "literal + derivation-expression comment" form from [Write derived values
+  and magic constants as literals…](#write-derived-values-and-magic-constants-as-literals-with-the-derivation-expression-added-as-a-comment)).
+- Add this boundary **in addition to** typical values (small integers like
+  `100001`). With typical values alone, an implementation that mistakenly
+  used `Number.isInteger` instead of `Number.isSafeInteger` would still pass
+  (the QA stance in [SKILL.md](../SKILL.md)).
+- For features that **receive integers as strings** (e.g. the string
+  representation of a `bigint`), write values beyond the threshold as string
+  or `BigInt` literals ([Write derived values and magic constants as
+  literals…](#write-derived-values-and-magic-constants-as-literals-with-the-derivation-expression-added-as-a-comment)).
+
+```js
+describe('SomeIntegerScalar', () => {
+  describe('#normalizeValue()', () => {
+    describe('with valid values', () => {
+      const cases = [
+        {
+          input: {
+            value: 100001, // typical value
+          },
+          expected: 100001,
+        },
+        {
+          input: {
+            value: Number.MAX_SAFE_INTEGER, // boundary of a safe integer
+          },
+          expected: Number.MAX_SAFE_INTEGER,
+        },
+      ]
+      // ...
+    })
+
+    describe('with invalid values', () => {
+      const cases = [
+        {
+          input: {
+            value: Number.MAX_SAFE_INTEGER + 1, // just outside the safe range → not a safe integer
+          },
+        },
+        // ...
+      ]
+      // ...
+    })
+  })
+})
+```
+
+## For variable-count elements, cover the count boundaries down to (…3, 2, 1, 0)
+
+When a member processes **a variable number of elements** (words joined by a
+delimiter, elements of an array/list, repetition, etc.), align not only the
+typical multiple-element case but also the **reduced-count boundaries**
+(3, 2, **1**, **0**). Element-count boundaries are fragile against branching
+and regex boundary conditions, and multi-element cases alone cannot verify
+the paths for "no delimiter at all (1 element)" or "empty (0 elements)."
+
+- **0 elements**: empty string `''`, empty array `[]`, input with no elements.
+- **1 element**: a single element with no delimiter. There's no processing
+  between elements (delimiting, joining, etc.), so this often goes through a
+  different path than the multi-element case (no transformation, pass-through, etc.).
+- **2 or more**: the typical case.
+
+### Treat count boundaries not as an "independent describe" but as symmetric combinations with existing axes
+
+Variations in count must **not be carved out into their own independent
+behavior describe or separate axis**. Extracting only the boundaries (1
+element, 0 elements) into a dedicated describe actually creates an asymmetry —
+"why is count treated specially on its own?" Count is merely **a variation of
+the input value**, so lay it out **symmetrically** within a **grid combined
+with the existing axis** (the other property/argument), for each axis value.
+
+- If another axis already exists, give **the same count range for each of
+  its values**. Avoid adding the boundary only to one specific axis value
+  (fixing one side, as described under [When multiple properties are
+  involved in the output](./structure.md#when-multiple-properties-are-involved-in-the-output-property--property)),
+  since that produces asymmetry.
+- Don't reason "the boundary produces the same output regardless of the
+  other axis, so it should be separated out." Even with some duplication,
+  aligning the **axis × count** grid keeps the structure symmetric and
+  readable, and gaps are less likely.
+- Ordering the counts from largest to smallest within each inner `cases`
+  groups the boundaries at the end, making them easier to read (the same
+  idea as [list normal values first](#list-normal-values-first)).
+
+## Split cases where a structural marker sits at a special position into a separate describe
+
+When a member consumes **structural markers** embedded in the input
+(delimiter/separator/quote/escape characters — characters that indicate
+token structure) as it processes them, verify cases where the marker sits at
+a **special position**. These go through **a different branch** from the
+usual "a marker sits between tokens" case (matching at the start / no
+following token at the end / a token being empty because it's only a marker),
+and often produce non-obvious results.
+
+- **Start**: a marker at the start of the input.
+- **End**: a marker at the end of the input (no following token).
+- **Both ends**: markers at both start and end.
+- **Marker only**: no tokens at all, just markers (one or several).
+
+### Treat this separately from count boundaries (reason for a separate describe)
+
+[Count boundaries](#for-variable-count-elements-cover-the-count-boundaries-down-to-3-2-1-0) are a
+continuous variation of the input value, so they get folded into the grid.
+A marker's special position, on the other hand, is **a qualitatively
+different edge** (a different path, a non-obvious result), so it is split
+into an independent behavior describe to make the intent explicit. Mixing it
+into the describe for normal processing would blur what is being verified.
+
+### The marker's value can change the behavior
+
+Even at the same special position, the result can branch depending on the
+marker's **value** (whether it belongs to a character class, whether it is a
+regex special character, etc.). Use representative values that cause the
+behavior to branch as an axis (`describe.each()`), and verify symmetrically.
+
+## Don't fill cases with edge cases only (always include typical values)
+
+Don't fill `cases` with **edge cases only**. If you line up only boundary,
+special, and abnormal values and drop the **typical (most ordinary) input**,
+you cannot verify that "normal usage works correctly," and the test bypasses
+the main use case. Put in typical values first, then add edges.
+
+- A common mistake: in an eagerness to **highlight** some behavior (the
+  effect of a flag, a special branch, etc.), you end up choosing only the
+  special inputs that show that difference. Inputs that show the difference
+  are necessary, but they must not be the **only** ones. Also include a
+  **typical input** for which there is no difference, and pin down the
+  result for the ordinary case too.
+  - For example, in a describe split by a mode flag (structure.md's "separate
+    mutually-influencing arguments with `describe()`"), there's a tendency to
+    skew toward special inputs where the flag has an effect. Also add a
+    **typical input unaffected by the flag** for each mode, pinning down that
+    "for typical inputs, the result is the same regardless of mode."
+- Decision procedure: look over `cases` and check whether it includes "the
+  input this member most commonly receives in real-world use." If not, add a
+  typical value (placed at the front — see the next section, "List normal
+  values first").
+
+## List normal values first
+
+Within a single `cases` array, place **representative normal values first**,
+and edge values such as `null` / `undefined` / empty arrays **later**. The
+reader first grasps the intent from the typical cases, and can check the
+edges together at the end.
+
+```js
+// Good example: normal values (arrays, functions) first, null at the end
+const cases = [
+  {
+    input: {
+      replacer: alphaReplacer,
+    },
+  },
+  {
+    input: {
+      replacer: betaReplacer,
+    },
+  },
+  {
+    input: {
+      replacer: null,
+    },
+  },
+]
+```
+
+```js
+// Avoid: placing null first buries the typical cases
+const cases = [
+  {
+    input: {
+      replacer: null,
+    },
+  },
+  // ... alphaReplacer / betaReplacer follow
+]
+```
+
+If type-violating irregular values are also included, use the Separate
+Valid / Invalid Values split in [structure.md](./structure.md) to separate
+`describe()`s instead of this ordering. The ordering here is only about the
+order **among valid values that live within the same `describe()`**.
+
+## At most one property key per line
+
+Format `cases` objects so that **no more than one property key (`foo:`)
+appears on a single line**.
+
+- Structural containers (where the value of `input` / `tally` / `override`
+  is an object) must **always be broken onto new lines**, with child
+  properties on separate lines. Don't put parent and child on the same line
+  like `input: { replacer: X }`.
+- Leaf data values (payload objects held by things like `value` /
+  `valueHash`) **may be inline if there is a single key**
+  (`valueHash: { id: 100001 }`). **Expand if there are multiple keys**.
+- When placing multiple objects inside an array too, **expand each element
+  onto its own line**. If an element has just a single key, it may be inline.
+
+```js
+// Avoid: placing input and replacer on the same line (inlining a structural container)
+const cases = [
+  { input: { replacer: alphaReplacer } },
+]
+
+// Avoid: placing value and id / name on the same line (inlining a multi-key payload)
+const cases = [
+  {
+    input: {
+      value: { id: 100001, name: 'Alpha' },
+    },
+  },
+]
+
+// Avoid: placing multiple objects on one line inside an array
+const cases = [
+  {
+    input: {
+      value: [{ id: 100001 }, { id: 100002 }],
+    },
+  },
+]
+```
+
+```js
+// Good example: break structural containers onto new lines, expand multi-key payloads and multiple elements
+const cases = [
+  {
+    input: {
+      value: {
+        id: 100001,
+        name: 'Alpha',
+      },
+    },
+  },
+  {
+    input: {
+      value: [
+        { id: 100001 }, // single-key elements may be inline
+        { id: 100002 },
+      ],
+    },
+  },
+]
+```
+
+## Don't put branches into sample functions
+
+For **sample callback functions** passed into `cases` (`replacer` /
+comparator, etc.), avoid **branches (`if` / ternary)** as much as possible,
+and keep them a simple transformation. What the test wants to confirm is
+"whether that function is passed and applied correctly," not the logic
+inside the function itself, so a branch becomes noise and makes it look like
+you're verifying the sample function's own behavior.
+
+```js
+// Good example: a simple transformation with no branching
+const alphaReplacer = (key, value) => `*${value}`
+```
+
+```js
+// Avoid: includes branching logic (unclear what is being verified)
+const alphaReplacer = (key, value) =>
+  key === 'secret'
+    ? undefined
+    : value
+```

--- a/kit/skills/core/hc-jest/references/types.md
+++ b/kit/skills/core/hc-jest/references/types.md
@@ -1,0 +1,471 @@
+# Types (type resolution)
+
+Convention for type annotations and type resolution in Jest. Referenced from `SKILL.md`.
+
+## Type Resolution
+
+Attach a type annotation to `cases` **only when needed to resolve or suppress
+a type error**. The purpose of `@type` is to make the type check pass; if the
+correct type can be inferred from the literal and there is no type error
+whether or not you attach it, it is **redundant, so it can be omitted**.
+
+A cast via `@type {Array<*>}` should be limited to suppressing type errors
+**to write irregular values** (`null` / `undefined` / missing keys, etc. that
+violate the declared type). Irregular values are isolated into the
+**abnormal-value-series `describe()`** by the valid/invalid separation
+([Separate Valid / Invalid
+Values](./structure.md#separate-valid--invalid-values)), so **only the
+abnormal-value series needs the cast**.
+
+- Normal-value series: if the value conforms to the type and the type can be
+  correctly inferred from the literal, `@type` **may be omitted** (it's
+  redundant since there's no type error). Attach `@type` only when inference
+  alone wouldn't produce the intended type, or when you want to make it
+  explicit for some other reason (and even then, do **not** add the
+  `Array<*>` cast).
+- Abnormal-value series: since you are deliberately passing type-violating
+  values, cast the array literal with `@type {Array<*>}` in addition to
+  `@type`, to suppress the intentional type error.
+
+### Whether `@type` is needed should be confirmed with a type checker (where `tsc` is available)
+
+To correctly judge "it can be omitted if there's no type error," you need to
+**actually check whether a type error occurs, using a type checker**. **Where
+`tsc` is available**, confirm with `npx tsc -p jsconfig.json --noEmit` (adjust
+to the project's type-check configuration).
+
+- **A clean `eslint` run is not proof of type resolution**. ESLint does not
+  report `checkJs` type errors (`TS2769` overload mismatch / `TS2345` type
+  incompatibility / `TS2349` not callable, etc.), so types may be broken even
+  when `eslint` passes. Don't conclude "`@type` is unnecessary because eslint
+  is clean."
+- Real examples that are easy to miss: an overload mismatch in `test.each`
+  lining up dynamic keys `Record<string, *>`, a not-callable error from
+  calling a getter that returns a function as `predicate(value)`, a test
+  stub that doesn't match a declared type (e.g. `ConstraintCtor`). eslint
+  passes through all of these.
+- In environments where `tsc` is unavailable, verify **by hand**, guided by
+  the decision procedures in each section of this file (dynamic keys,
+  generic base classes, function-returning getters, etc.).
+
+```js
+// Normal value (type can be inferred from the literal, so @type is omitted)
+const cases = [
+  // ...
+]
+
+// Abnormal value (writes irregular values, so a cast is used)
+/**
+ * @type {Array<{
+ *   input: {
+ *     templatePathname: string
+ *   }
+ *   valueHashCases: Array<{
+ *     valueHash: Record<string, *>
+ *     expected: string
+ *   }>
+ * }>}
+ */
+const cases = /** @type {Array<*>} */ ([
+  // ... null / undefined / missing keys, etc.
+])
+```
+
+## `TS2769` from passing a union type to an overloaded function is resolved with `Parameters<typeof Fn>[N]`
+
+Passing a value of **a union type that spans** the parameter shapes of
+multiple overloads to a function that has **multiple overloads**, like
+`JSON.stringify`, matches none of the overloads and produces `TS2769` (No
+overload matches this call). For example, if `replacer`'s type is
+`((key, value) => *) | Array<string | number> | null`, it fits neither the
+"function" overload nor the "array" overload.
+
+The resolution is to **cast that argument to the type of the matching
+overload's parameter**. Rather than spelling out a hand-written type,
+referencing it via `Parameters<typeof Fn>[N]` (the type of `Fn`'s Nth
+parameter) is accurate and keeps up with signature changes.
+
+- The cast is placed **inline at the value position (right before the
+  argument)**. Since this is not an assignment but an argument in an
+  expression, it is exempt from [Write the type of an assigned value above
+  the statement](#write-the-type-of-an-assigned-value-above-the-statement) — it should not become a
+  statement-level declaration.
+- This is **different** from "cast away a normal value" (forbidden in [For
+  normal values, don't cast — prepare a real value matching the declared
+  type](#for-normal-values-dont-cast--prepare-a-real-value-matching-the-declared-type)). The value stays a
+  legitimately typed union value; the cast is to resolve overload-resolution
+  constraints, which is a different purpose from an `Array<*>` value cast
+  applied to an abnormal value that **violates** the declared type.
+- The same thing shows up in test code (e.g. passing a union fixture for
+  replacer/reviver to `JSON.stringify`). Align it with the same style used to
+  resolve this on the source side.
+
+```js
+// TS2769: replacer's union type matches no overload
+return JSON.stringify(value, this.replacer)
+
+// Resolution: cast to the type of the matching argument (2nd argument = [1])
+return JSON.stringify(
+  value,
+  /** @type {Parameters<typeof JSON.stringify>[1]} */ (this.replacer)
+)
+```
+
+## Fix normal-value cases involving `Record<string, *>` (dynamic keys), etc., with a `@type` declaration
+
+When the test target receives an argument with **a type that has no concrete
+keys**, such as `Record<string, *>` (an index signature / dynamic keys), a
+literal written into cases like `{ id: 100001 }` / `{ value: false }` gets
+inferred as a **concrete key type** such as `{ id: number }` /
+`{ value: boolean }` respectively. Because the shape of `valueHash` then
+disagrees across cases, a **type error** occurs at the point where it's
+passed to `test.each()` or to `method(args)`.
+
+In this case, attach **only a declaration** of `@type {Array<{...}>}` to
+`cases`, fixing the target field to the type on the declaration side (e.g.
+`Record<string, *>`). Attaching the declaration aligns every case's value to
+a single type, eliminating the inference drift and resolving the type error.
+
+- Since this is a **normal value** (the value conforms to the declared type),
+  do **not** add the `/** @type {Array<*>} */` **value cast**. The `Array<*>`
+  value cast is the last resort for writing an irregular value that
+  **violates** the declared type (abnormal-value series) ([Type
+  Resolution](#type-resolution)). If you just want to fix the type for a
+  normal-value series, the `@type` declaration alone is enough.
+- This is an **exception** to "normal-value series can omit `@type` since it
+  can be inferred from the literal" ([Type Resolution](#type-resolution)).
+  When a dynamic-key type such as `Record<string, *>` is involved, plain
+  inference does not produce a matching type, so in this case you attach the
+  declaration rather than omitting it.
+- Rule of thumb: if the source-side `@param` has **a non-fixed-key type**
+  such as `Record<string, *>` / `{ [key: string]: * }` / `object`, and the
+  cases line up **multiple literals with different keys**, attach a `@type`
+  declaration.
+
+```js
+// Normal value, but with a Record<string, *> argument. Attach only a declaration (no value cast)
+describe('with valid values', () => {
+  /**
+   * @type {Array<{
+   *   input: {
+   *     templatePathname: string
+   *   }
+   *   valueHashCases: Array<{
+   *     valueHash: Record<string, *>
+   *     expected: string
+   *   }>
+   * }>}
+   */
+  const cases = [
+    {
+      input: {
+        templatePathname: '/users/[id]',
+      },
+      valueHashCases: [
+        {
+          valueHash: { id: 100001 }, // plain inference would make this { id: number }, disagreeing with Record
+          expected: '/users/100001',
+        },
+        // ... postId/commentId, value: false, etc. — literals with different keys continue
+      ],
+    },
+  ]
+  // ...
+})
+```
+
+```js
+// Contrast: an abnormal value needs both the declaration and the Array<*> value cast (since it writes a type-violating value)
+/**
+ * @type {Array<{
+ *   input: {
+ *     templatePathname: string
+ *   }
+ *   valueHashCases: Array<{
+ *     valueHash: Record<string, *>
+ *     expected: string
+ *   }>
+ * }>}
+ */
+const cases = /** @type {Array<*>} */ ([
+  // ... null / undefined / missing keys, etc.
+])
+```
+
+## `@type` declarations on `cases` must type every field precisely (don't paper over with `*`)
+
+Once you decide to attach a `@type` declaration to `cases`, **write out each
+field inside it with its actual type**. Do not escape into `*` (any) for a
+field just because typing it is bothersome or non-obvious, as in
+`expected: *`. The purpose of the declaration is to **fix** the type and
+eliminate inference drift/mismatch; a `*` field fixes nothing, and in fact
+**buries a type mismatch that could otherwise be detected**. Once you commit
+to attaching a declaration, mixing in `*` is self-contradictory.
+
+- As noted in [Type Resolution](#type-resolution), `*` is the last resort
+  used as the `Array<*>` value cast for the **abnormal-value series**
+  (writing irregular values that violate the declared type). Don't habitually
+  use `*` for fields of a **normal-value** `@type` declaration.
+- Even if a field's type isn't obvious, write **a type derivable from an
+  existing value**. Deriving it from the test target or its return value
+  aligns the types of `received` and `expected`, backing the `.toBe()`
+  comparison with types too. Example: when looking up a value in a
+  namespace, use `(typeof ScalarHash)[keyof typeof ScalarHash]` (i.e. one of
+  the exported values); for a class, `typeof SomeClass`; for an instance,
+  `SomeClass`.
+- "Write any as `*`" ([Write any as `*`](#write-any-as-)) is about places
+  that are **genuinely fine as any** (implicit any arguments of a fixture,
+  etc.). It is not an excuse to make a field that **has a concrete type**,
+  like `expected`, into `*`.
+
+```js
+// Good: write expected out with its real type too (aligns the type with received)
+/**
+ * @type {Array<{
+ *   input: {
+ *     name: keyof typeof ScalarHash
+ *   }
+ *   expected: (typeof ScalarHash)[keyof typeof ScalarHash]
+ * }>}
+ */
+const cases = [
+  // ...
+]
+```
+
+```js
+// Avoid: attaching a declaration but then escaping expected into * (buries the type mismatch)
+/**
+ * @type {Array<{
+ *   input: {
+ *     name: keyof typeof ScalarHash
+ *   }
+ *   expected: *
+ * }>}
+ */
+const cases = [
+  // ...
+]
+```
+
+## For normal values, don't cast — prepare a real value matching the declared type
+
+When a type error occurs for a normal-value series, it is often a sign that
+"the value doesn't match the declared type." **Before** papering it over with
+`/** @type {*} */` or `Array<*>`, first consider **whether the value can be
+swapped for a real value that matches the declared type**. A cast is a last
+resort for writing an irregular value (abnormal-value series), not something
+to use to hide a type mismatch in a normal value.
+
+- If the argument's declared type is **a concrete object type** (`WeakMap` /
+  `Map` / `Set` / a specific instance, etc.), pass **a real instance of that
+  type** (`new WeakMap()`, etc.) rather than a substitute literal like
+  `{ id: 100001 }`. This way, neither `@type` nor a cast is needed, and the
+  type simply passes.
+- Passing a substitute literal and suppressing it with a cast (1) breaks the
+  meaning of the type, and (2) makes it impossible for the test to verify
+  whether the implementation truly requires that type.
+- Real instances are often opaque and can't carry a readable index. In that
+  case, follow the `$#` numbering scheme in
+  [test-cases.md](./test-cases.md#for-opaque-value-titles-too-first-use-a-readable-identifying-property--is-a-last-resort)
+  for the case title.
+
+```js
+// Avoid: passing a plain object for a declared WeakMap type and suppressing it with a cast
+const cases = [
+  {
+    input: {
+      weakMapKey: /** @type {*} */ ({ id: 100001 }),
+    },
+  },
+]
+
+// Good: pass a real instance matching the declared type (no cast needed, type passes)
+const cases = [
+  {
+    input: {
+      weakMapKey: new WeakMap(),
+    },
+  },
+]
+```
+
+## Write any as `*`
+
+When representing "any" in a JSDoc type annotation, use `*` rather than the
+literal `any` (e.g. `(key: string, value: *) => *`, `@param {{ value: * }}`).
+The source-side JSDoc also uses `value: *`, so align with it.
+
+## Resolve implicit-any fixtures with `@type`
+
+When a fixture arrow function has an implicit-any argument and breaks the
+type check (e.g. `key` / `value` in
+`const alphaReplacer = (key, value) => value`), resolve it with a `@type`
+annotation **rather than rewriting the value to avoid the type error**. Write
+any as `*`.
+
+```js
+/** @type {(key: string, value: *) => *} */
+const alphaReplacer = (key, value) => value
+```
+
+### For a function's implicit-any arguments, type with `@param` (`@returns` is required, multi-line block)
+
+When the implicit any is **a function's argument**, it is more straightforward
+to **type just the argument with `@param`** rather than writing the whole
+function with `@type` (since `@param` points directly at where the implicit
+any lives, i.e. the argument). If it's a property of an object literal, like
+`const args = { deriver: ({ Ctor }) => ... }`, place it **directly above that
+property**; for a standalone `const`, place it directly above that.
+
+Note the ESLint (jsdoc plugin) constraints:
+- Once you write `@param`, **`@returns` is also mandatory**
+  (`jsdoc/require-returns`). It cannot be omitted if the function returns a value.
+- A block containing `@param` **cannot be a single line**
+  (`jsdoc/multiline-blocks`; single-line is only allowed for some tags such as
+  `@type`). → It must always be written as a **multi-line block**.
+- A constructor type only needs `new () => *` if it's used only as
+  `extends` (no need to go as far as `new (...args: Array<*>) => *`).
+
+```js
+const args = {
+  /**
+   * @param {{ Ctor: new () => * }} params
+   * @returns {new () => *}
+   */
+  deriver: ({ Ctor }) => class extends Ctor {},
+}
+const deriverSpy = jest.spyOn(args, 'deriver')
+```
+
+A single-line `@type` (`/** @type {(key, value) => *} */`) also passes the
+type check, but that writes the type of the **whole** function. If all you
+want is to resolve the implicit any on the argument, `@param` expresses the
+intent more clearly.
+
+## Write the type of an assigned value above the statement
+
+When explicitly stating **the type after assignment (the declaration)** of a
+value assigned to a variable, place `/** @type {...} */` **directly above the
+statement**. Don't stack a fixed cast inline on the value side.
+
+- Declare the type after assignment (i.e. the type that variable will hold
+  from here on) with `@type` on **the line above**.
+- When the right-hand-side value cannot be directly assigned to the declared
+  type (e.g. putting `jest.fn()` into a function type), bridge the gap with
+  **a single temporary `/** @type {*} */` cast on the value side**. Place
+  the temporary cast right before the value, keeping the declared type
+  separated onto the line above.
+- This way, "what is this variable's type" can be read in one line directly
+  above the declaration, and `*` is understood as playing the role of "a
+  temporary escape hatch just to let the assignment through."
+
+```js
+// Good: the type after assignment goes on the line above; the * temporary cast goes on the value side
+/** @type {typeof someFn} */
+const someFnSpy = /** @type {*} */ (jest.fn())
+```
+
+```js
+// Avoid: stacking a fixed cast on the value side (the declared type gets buried in the right-hand side)
+const someFnSpy = /** @type {typeof someFn} */ (/** @type {*} */ (jest.fn()))
+```
+
+### Resolve dynamic-key types on the `cases` side, keeping the access site and Arrange clean
+
+When looking up a namespace or object using a `cases` value (e.g.
+`input.name`) as a **dynamic key** (`ScalarHash[input.name]`), a fixed-key
+type cannot be indexed with `string` and produces a type error (`TS7053`). In
+this case, the first move is to resolve it by **narrowing the type of the
+`cases` that is the source of the key** — declare `input.name` as
+`keyof typeof <lookup target>` in the `@type` of `cases` (an application of
+[Fix normal-value cases involving dynamic keys with a `@type`
+declaration](#fix-normal-value-cases-involving-recordstring--dynamic-keys-etc-with-a-type-declaration)).
+
+- **Why on the `cases` side**: (1) The access site `ScalarHash[input.name]`
+  can be read as a **plain expression with no cast**, keeping the test's main
+  point (what is looked up and compared against what) clear. (2) The key
+  string is **type-checked against the actual key set** of the lookup target,
+  so a typo in an alias name or an export rename can be caught by the type
+  system (a stronger contract).
+- **Alternatives to avoid**:
+  - A **type-resolution-only intermediate variable** (creating
+    `const scalarHash = ScalarHash` just to do `scalarHash[key]`). This
+    inserts an assignment into Arrange that's unrelated to the test, just to
+    make one lookup work, diluting the AAA intent (noise for the reader).
+  - A **value-position cast at the access site**
+    (`/** @type {Record<string, *>} */ (ScalarHash)[key]`). The type passes,
+    but it degrades to a `string` index, so **the key's type check no longer
+    applies**, and noise remains in the access expression too.
+- A value-position cast is appropriate only when **the key does not come
+  from `cases`** (e.g. it's generated on the spot and cannot be constrained
+  by the type of `cases`). If an element of `cases` is used as the key,
+  always resolve it on the cases side.
+
+```js
+// Good: narrow input.name to keyof via the type of cases → the access site needs no cast
+/**
+ * @type {Array<{
+ *   input: {
+ *     name: keyof typeof ScalarHash
+ *   }
+ *   expected: (typeof ScalarHash)[keyof typeof ScalarHash]
+ * }>}
+ */
+const cases = [
+  {
+    input: {
+      name: 'Bool',
+    },
+    expected: BooleanScalar,
+  },
+  // ...
+]
+
+test.each(cases)('name: $input.name', ({ input, expected }) => {
+  const received = ScalarHash[input.name] // no cast needed; the key is already type-checked
+
+  expect(received)
+    .toBe(expected) // same reference
+})
+```
+
+```js
+// Avoid: a value-position cast (the key's type check no longer applies, and noise remains in the expression)
+const received = /** @type {Record<string, *>} */ (ScalarHash)[input.name]
+
+// Avoid: a type-resolution-only intermediate variable (inserts an assignment unrelated to Arrange)
+/** @type {Record<string, *>} */
+const scalarHash = ScalarHash
+const received = scalarHash[input.name]
+```
+
+## If a derived class defined for testing extends a generic class, resolve it with `@extends`
+
+When a derived class defined inside a test (the kind used for a variable
+element in `#get:Ctor`, or a class-name difference in `when not inherited`,
+such as `class AlphaSub extends SomeBase {}`) `extends` **a generic class
+that has `@template`**, attach a JSDoc `@extends {Base<...>}` directly above
+that class declaration to **resolve the generics**. Without it, the type
+arguments remain unspecified, and the editor/tsc warns that "type arguments
+are missing."
+
+- Ideally you'd write the concrete type if it's determined, but for a
+  test-only vessel it's **fine to paper over it with `*`**
+  (`@extends {SomeBase<*, *>}`). The **number** of type arguments should match
+  the number of class-level `@template` parameters on the base class (if
+  `SomeBase` has `@template A, B` — 2 parameters — use `<*, *>`).
+- This may be written as a single-line block
+  (`/** @extends {SomeBase<*, *>} */`).
+- This applies only when **directly extending a generic base class**. It is
+  unnecessary for a derived class that extends a class whose type arguments
+  are already fixed (`class Foo extends SomeFixedBase {}`, where
+  `SomeFixedBase` is already defined as `SomeBase<string, string>`).
+
+```js
+/** @extends {SomeBase<*, *>} */
+class AlphaSub extends SomeBase {}
+
+/** @extends {SomeBase<*, *>} */
+class BetaSub extends SomeBase {}
+```

--- a/kit/skills/core/hc-jsdoc/SKILL.md
+++ b/kit/skills/core/hc-jsdoc/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: hc-jsdoc
+description: "JSDoc writing conventions shared by backend and frontend. Use when writing or reviewing JSDoc type annotations, in plain JavaScript or in Vue."
+---
+
+# Shared: JSDoc
+
+Summarizes JSDoc writing conventions. All typing is JSDoc — no TypeScript syntax, no `.ts`
+files — so always annotate types with JSDoc.
+
+The rules in this body apply to every JavaScript file, backend and frontend alike. Conventions
+that only apply when writing Vue / Nuxt (block placement, Furo class and factory typing, Vue
+`PropType`, ambient globals) are in the reference files listed at the end, each marked with
+its scope.
+
+> How the jsdoc-plugin rules actually in effect under this project's ESLint map to
+> each of this skill's conventions is summarized in
+> [eslint-jsdoc-rules.md](./references/eslint-jsdoc-rules.md). If you write JSDoc as
+> this skill prescribes, `npm run lint` produces no jsdoc-related errors. Note that
+> lint also enforces such points as: `function` declarations and methods must have
+> JSDoc (empty constructors are not exempt), each `@param` requires a type and a name,
+> and a function that returns a value needs `@returns` (with a type). This skill goes
+> one step further and requires `@returns` even when nothing is returned (`{void}`).
+
+## Write object types with named parameters
+
+- Do not use `{object}`.
+- Write objects as an inline type literal, explicitly listing each property as a named parameter.
+
+Example:
+
+```javascript
+// NG
+/**
+ * @param {object} params - Parameters.
+ * @param {string} params.alpha - Alpha.
+ */
+
+// OK
+/**
+ * @param {{
+ *   alpha: string
+ * }} params - Parameters.
+ */
+```
+
+## Name a single object argument `params`
+
+- For a method that takes a single object argument, name the parameter `params` unless there is a special reason not to.
+
+```javascript
+// OK
+/**
+ * @param {{
+ *   alpha: string
+ * }} params - Parameters.
+ */
+```
+
+## Always write `@returns`
+
+- Every function and method gets `@returns`, even one that returns nothing.
+- For a function that returns nothing, write `@returns {void}` (`@returns {Promise<void>}`
+  when it is async). Never omit the tag.
+- Lint (`jsdoc/require-returns`) only demands `@returns` when a value is actually returned,
+  so this skill is stricter than lint here (see
+  [eslint-jsdoc-rules.md](./references/eslint-jsdoc-rules.md)). The reason is that "returns
+  nothing" should be stated, not inferred from the absence of a tag.
+
+```javascript
+// NG: returns nothing, so @returns is omitted
+/**
+ * @param {{
+ *   message: string
+ * }} params - Parameters.
+ */
+
+// OK
+/**
+ * @param {{
+ *   message: string
+ * }} params - Parameters.
+ * @returns {void}
+ */
+```
+
+## Attach a description to `@returns`
+
+- Attach not just a type but also a description to `@returns`.
+- The sole exception is `@returns {void}` / `@returns {Promise<void>}`. There is no
+  returned value to describe, so the type stands on its own.
+- Do not put a hyphen between the type and the description. The leading `- ` is a
+  `@param` convention (`jsdoc/require-hyphen-before-param-description`) and does not
+  apply to `@returns`.
+- Lint (`jsdoc/require-returns-description`) is off and does not force a description,
+  but this skill always attaches one for QA reasons (see
+  [eslint-jsdoc-rules.md](./references/eslint-jsdoc-rules.md)).
+
+```javascript
+// NG: no description
+/**
+ * @returns {string}
+ */
+
+// NG: a hyphen before the description
+/**
+ * @returns {string} - Default characters to pick from.
+ */
+
+// OK
+/**
+ * @returns {string} Default characters to pick from.
+ */
+```
+
+## Add `@public` to entry points
+
+- Add `@public` to the JSDoc of any method that serves as an entry point accessed from outside.
+
+```javascript
+/**
+ * Generate a random text of the given length.
+ *
+ * @param {{
+ *   length: number
+ * }} params - Parameters.
+ * @returns {string | null} Generated random text, or null if it cannot be generated.
+ * @public
+ */
+generate ({
+  length,
+}) {
+  // ...
+}
+```
+
+## Write array types as `Array<T>`
+
+- Trailing-`[]` array notation such as `string[]` is prohibited. Always write it as `Array<string>`.
+- Reason: writing something like `{ alpha: number, beta: string }[]` causes confusion for the reader.
+
+```javascript
+// NG
+/**
+ * @param {string[]} values - Values.
+ */
+
+// OK
+/**
+ * @param {Array<string>} values - Values.
+ */
+```
+
+## Avoid vague types; write the most specific type you can
+
+- Vague types such as `object` / `Object` / `any` / `*` are not used unless clearly necessary.
+- Investigate the type and write it as a type literal with the most detailed properties possible,
+  or as a concrete type name.
+- Make generics concrete as far as possible. Do not leave the element type vague as
+  `Array<object>`; write `Array<UserEntity>` instead.
+
+```javascript
+// NG: vague element type and return type
+/**
+ * @param {{
+ *   users?: Array<object>
+ * }} params - Parameters.
+ * @returns {object} Users and their total count.
+ */
+
+// OK: investigate and write the detailed type
+/**
+ * @param {{
+ *   users?: Array<UserEntity>
+ * }} params - Parameters.
+ * @returns {{
+ *   users: Array<UserEntity>
+ *   total: number
+ * }} Users and their total count.
+ */
+```
+
+### `object` / `Object` is prohibited; use `Record<string, *>`
+
+- `object` / `Object` is prohibited regardless of the reason.
+- Reason: `object` is dangerous in that it tolerates ambiguity including `null`. Even when you are
+  forced to represent an object with unknown keys, `Record<string, *>` is better.
+- Still, `Record<string, *>` is a last resort too; write a type literal with explicit properties
+  wherever possible.
+
+```javascript
+// NG
+/**
+ * @param {object} config - Config.
+ */
+
+// BETTER: when the keys are genuinely unknown
+/**
+ * @param {Record<string, *>} config - Config.
+ */
+
+// BEST: when you can list the properties
+/**
+ * @param {{
+ *   host: string
+ *   port: number
+ * }} config - Config.
+ */
+```
+
+## Do not write undefined type names (define custom types before referencing them)
+
+- For type names written in JSDoc, anything other than built-in types (`string` / `number` /
+  `boolean` / `Array` / `Object` / `*` / `null`, etc.) and TS utility types (`Record` / `Partial` /
+  `Pick` / `Omit` / `ReturnType`, etc.) must be **defined before** it is referenced, via one of
+  `@typedef` / `@class` / `@interface` / import.
+- Do not write undefined type names. Reason: they are a common source of typos and missing imports.
+- For example, to write `Array<UserEntity>` from the previous section, a `@typedef` (or the like) for
+  `UserEntity` must exist in the same file (or its import source).
+
+```javascript
+// NG: UserEntity is not defined anywhere
+/**
+ * @param {{
+ *   users?: Array<UserEntity>
+ * }} params - Parameters.
+ */
+
+// OK: define it with @typedef before referencing it
+/**
+ * @typedef {{
+ *   id: number
+ *   name: string
+ * }} UserEntity
+ */
+
+/**
+ * @param {{
+ *   users?: Array<UserEntity>
+ * }} params - Parameters.
+ */
+```
+
+> The undefined-type-name check (`jsdoc/no-undefined-types`) is **off** by default in
+> `@openreachtech/eslint-config`, so this skill enforces it rather than relying on lint.
+
+## Do not write `undefined` as a type (use `null`)
+
+- Do not write `undefined` in a type, as in `@returns {string | undefined}` or `@param {undefined}`.
+- Express "no value" with `null`, not `undefined` (e.g. `@returns {string | null}`).
+- For a function that returns nothing, write `@returns {void}`, not `@returns {undefined}`
+  (see "Always write `@returns`" above).
+- Exception: when a third-party module or the like requires `undefined`, you may write `undefined` in
+  `@returns` and so on. If there is a way to avoid `undefined`, prefer that.
+
+```javascript
+// NG
+/**
+ * @returns {string | undefined} Generated text.
+ */
+
+// OK
+/**
+ * @returns {string | null} Generated text.
+ */
+```
+
+## Write the any type as `*`
+
+- To express an arbitrary (any) type, use `*`. Do not use `any`.
+- Still, `*` (any) itself is not overused, per "Avoid vague types; write the most specific type you
+  can" above. Write `*` (not `any`) only when the type cannot be narrowed and any is unavoidable.
+
+```javascript
+// NG
+/**
+ * @param {any} value - Value.
+ */
+
+// OK
+/**
+ * @param {*} value - Value.
+ */
+```
+
+## Do not place a delimiter after each chopped-down property
+
+- When chopping down the `@param` for named arguments, do not place a semicolon or comma after each property.
+
+```javascript
+// OK
+/**
+ * @param {{
+ *   alpha: number
+ *   beta: number
+ * }} params - Parameters.
+ */
+```
+
+## Writing `@typedef`
+
+- Write `@typedef` as a block comment of at least three lines. A single-line
+  `@typedef` is also prohibited by lint (`jsdoc/multiline-blocks`).
+- Define one `@typedef` per block.
+- Separate `@typedef` block comments from one another with a blank line.
+
+```javascript
+// NG: written on a single line
+/** @typedef {*} BooleanLike */
+
+// NG: multiple @typedef in one block
+/**
+ * @typedef {*} BooleanLike
+ * @typedef {{
+ *   id: number
+ *   name: string
+ * }} UserEntity
+ */
+
+// OK: at least three lines, one per block, separated by a blank line
+/**
+ * @typedef {*} BooleanLike
+ */
+
+/**
+ * @typedef {{
+ *   id: number
+ *   name: string
+ * }} UserEntity
+ */
+```
+
+## Type-only imports
+
+- To reference a type declared in another module, use a type-only import. Never use the
+  TypeScript `import type` statement — it is not available in a JavaScript-only project.
+- Two styles exist: the `@import` block tag and the inline `import('…')` expression. **Follow
+  the style the repository has established, and do not mix both for the same type.** Furo /
+  Nuxt apps use `@import`; renchan backends use the inline `import('…')` expression. If a
+  repository has established neither, prefer `@import`.
+- One `@import` tag per JSDoc block, one source module per block — the same rule as `@typedef`
+  above.
+
+```javascript
+// OK: the @import block tag
+/**
+ * @import {
+ *   Reactive,
+ * } from 'vue'
+ */
+
+// OK: the inline import('…') expression
+/**
+ * @returns {import('./CustomerOrdersBk.js').default} Backup model declaration.
+ */
+```
+
+See [import-tag.md](./references/import-tag.md) and
+[import-expression.md](./references/import-expression.md) for each style in full.
+
+## References
+
+| Reference | Scope | Topic |
+| --- | --- | --- |
+| [eslint-jsdoc-rules.md](./references/eslint-jsdoc-rules.md) | Common | ESLint (jsdoc plugin) mapping — follow it and `npm run lint` passes / where this skill is stricter than lint / intentionally relaxed rules |
+| [import-tag.md](./references/import-tag.md) | Common | Type-only import via the `@import` block tag — placement, named/default forms, source modules, consuming by bare name |
+| [import-expression.md](./references/import-expression.md) | Common | Type-only import via the inline `import('…')` expression — forms, use sites, trade-offs vs `@import` |
+| [placement.md](./references/placement.md) | Frontend | Where `@typedef` / `@import` blocks go, inline `@type` on reactive declarations, Params / FactoryParams naming |
+| [class-typing.md](./references/class-typing.md) | Frontend | Params / FactoryParams typedef pair, `create()` factory template idiom, `@template` / `@extends` / `@override` / `@property` |
+| [vue-props-and-globals.md](./references/vue-props-and-globals.md) | Frontend | Vue `PropType` on prop definitions, ambient globals used unqualified |

--- a/kit/skills/core/hc-jsdoc/references/class-typing.md
+++ b/kit/skills/core/hc-jsdoc/references/class-typing.md
@@ -1,0 +1,75 @@
+# Classes & Factories
+
+Frontend (Vue / Nuxt) only — the Furo Context and `app/modules/` class conventions.
+
+## The Params / FactoryParams typedef pair
+
+Every class that has a `create()` factory declares a `<ClassName>Params` typedef and a derived `<ClassName>FactoryParams`. Context params extend `BaseFuroContextParams`:
+
+```js
+/**
+ * @typedef {BaseFuroContextParams & {
+ *   customerStore: CustomerStore
+ *   errorMessageHashReactive: Reactive<ErrorMessageHash>
+ *   formClerk: ReturnType<typeof useFormClerk>
+ * }} UpdateEmailSubmitterContextParams
+ */
+
+/**
+ * @typedef {UpdateEmailSubmitterContextParams} UpdateEmailSubmitterContextFactoryParams
+ */
+```
+
+When `create()` defaults some keys via DI, make those optional in FactoryParams with `RequiredExcept` (an ambient global helper — see below):
+
+```js
+/**
+ * @typedef {BaseFuroContextParams<ComponentProps> & {
+ *   currencyFormatter: Intl.NumberFormat
+ * }} OrderDetailProductContextParams
+ */
+
+/**
+ * @typedef {RequiredExcept<OrderDetailProductContextParams, 'currencyFormatter'>} OrderDetailProductContextFactoryParams
+ */
+```
+
+Common variants: `RequiredExcept<..., 'currencyFormatter'>`, `RequiredExcept<..., 'eventListenerAbortController'>`, `RequiredExcept<..., 'dateTimeFormatter' | 'currencyFormatter'>`, `RequiredExcept<..., FactoryOmittedKeys>` (a named union). When no keys are optional, FactoryParams simply aliases Params.
+
+## The `create()` factory template idiom
+
+Identical in Context classes and `app/modules/` classes ([[hf-furo-context-patterns]], [[utility-modules]]):
+
+```js
+/**
+ * @template {X extends typeof OrderDetailProductContext ? X : never} T, X
+ * @override
+ * @param {OrderDetailProductContextFactoryParams} params
+ * @returns {InstanceType<T>} Instance of this class.
+ * @this {T}
+ */
+static create ({
+  // ...
+}) {
+  return /** @type {InstanceType<T>} */ (
+    new this({
+      // ...
+    })
+  )
+}
+```
+
+## Class-level annotations
+
+- **`@template` with constraints** in generics: `@template {(...args: Array<unknown>) => void} T`, `@template {GraphqlType.LauncherCtor} L`.
+- **`@extends`** on the class doc: `@extends {BaseAppContext<null, ComponentProps, null>}` for contexts; `@extends {BaseGraphqlCapsule<D>}` with `@template D` for capsules.
+- **`@override`** on overridden statics/getters — notably `static create`, `static get EMIT_EVENT_NAME`, `static get document`.
+- **Class field types** via `@property` in the class-level doc, or captured through the constructor's params typedef:
+
+```js
+/**
+ * Timer Clerk
+ *
+ * @property {NodeJS.Timeout | number | null} lastTimer - Last timer
+ */
+```

--- a/kit/skills/core/hc-jsdoc/references/eslint-jsdoc-rules.md
+++ b/kit/skills/core/hc-jsdoc/references/eslint-jsdoc-rules.md
@@ -1,0 +1,117 @@
+# ESLint (jsdoc plugin) mapping
+
+This maps the jsdoc rules **actually in effect** under this project's ESLint
+configuration (`eslint-plugin-jsdoc`, bundled by `@openreachtech/eslint-config`) to
+how this skill writes JSDoc. **If you write JSDoc as this skill prescribes,
+`npm run lint` produces no jsdoc-related errors.** Items that overlap with
+conventions in other files reinforce one another.
+
+> The settings are layered. The base is `@openreachtech/eslint-rules-default-jsdoc`
+> (nearly every rule is `error`); on top of it, `configurations/plugins/jsdoc.js` in
+> `@openreachtech/eslint-config` turns some rules `off` or swaps their options. For
+> the actual values, see those two files.
+
+## Must follow (rules that error)
+
+### Presence and targets of blocks
+
+- **`function` declarations and methods (`MethodDefinition`) must have JSDoc.** Empty
+  constructors and empty functions are not exempt (`exemptEmptyConstructors: false` /
+  `exemptEmptyFunctions: false`). Arrow functions, function expressions, and class
+  declarations themselves are not targeted. — `jsdoc/require-jsdoc`
+  (`contexts: ['FunctionDeclaration', 'MethodDefinition']`)
+- **Do not leave empty JSDoc blocks or empty descriptions.** —
+  `jsdoc/no-blank-blocks` / `jsdoc/no-blank-block-descriptions`
+- **Single-line blocks (`/** ... *&#47;`) are prohibited**; always write them across
+  multiple lines. The only exceptions are `lends` / `type`, plus `extends` /
+  `inheritdoc` / `override` added by this project. → This is what lint-enforces this
+  skill's "write `@typedef` on at least three lines." — `jsdoc/multiline-blocks`
+  (`noSingleLineBlocks: true`)
+
+### Types, `@param`, `@returns`
+
+- **`@param` is required for every argument, with a type and a name.** Destructured
+  (named) parameters are targeted too, and the documented name must match the actual
+  argument name. — `jsdoc/require-param` / `jsdoc/require-param-name` /
+  `jsdoc/require-param-type` / `jsdoc/check-param-names`
+- **Using `object` as a `@param` type forces you to document its sub-properties**
+  (`checkTypesPattern` matches `object` / `Object` / `Array`, etc.). → This skill's
+  "write it as an inline type literal instead of `{object}`" aligns with this and
+  avoids the extra reports. — `jsdoc/require-param` / `jsdoc/check-param-names`
+- **If you write a `@param` description, prefix it with a hyphen `- `** (the
+  description itself is not required; see "Intentionally relaxed" below). The rule
+  targets `@param` only, so a `@returns` description takes **no** hyphen. —
+  `jsdoc/require-hyphen-before-param-description` (`'always'`)
+- **A function that returns a value needs `@returns`, with a type, consistent with the
+  actual return.** A function that returns nothing is not targeted → **this skill is
+  stricter and asks for `@returns {void}` there too** (see the table below). —
+  `jsdoc/require-returns` / `jsdoc/require-returns-type` / `jsdoc/require-returns-check`
+- **A function that throws needs `@throws`; a generator needs `@yields`.** —
+  `jsdoc/require-throws` / `jsdoc/require-yields` / `jsdoc/require-yields-check`
+- **Write `@public` / `@private` / `@protected` / `@access` correctly and without
+  duplicates.** → This skill's "add `@public` to entry points" is validated under this
+  rule. — `jsdoc/check-access`
+- **Type syntax must not be broken (matched `{`–`}`, etc.).** — `jsdoc/check-syntax` /
+  `jsdoc/check-property-names` (when using `@property`)
+
+### Layout (rules, formatting, tag order)
+
+- **Every line must start with `*`.** — `jsdoc/require-asterisk-prefix` (`'always'`)
+- **Keep the `*` column aligned and the spacing after tags (one space after the tag /
+  type / name / hyphen).** — `jsdoc/check-alignment` / `jsdoc/check-line-alignment`
+- **Exactly one blank line between the description and the first tag; no blank lines
+  between tags; no blank line before the closing.** — `jsdoc/tag-lines`
+  (`'never'`, `startLines: 1`, `endLines: 0`, `applyToEndTag: true`)
+- **Order tags by the default `tagSequence`** (roughly
+  `@param` → `@returns` → `@throws` → … → `@public`/`@access` → `@example`), with no
+  blank lines between tags (`linesBetween: 0`). — `jsdoc/sort-tags`
+- **Do not place stray `*` (`**`) in the middle or at the end of a line** (leading
+  whitespace is allowed). — `jsdoc/no-multi-asterisks` (`allowWhitespace: true`)
+- **`@description` / `@param` / `@returns` and others are excluded from the indentation
+  check**, but the body indentation of other tags is inspected. —
+  `jsdoc/check-indentation`
+
+## How each of this skill's conventions maps to the rules
+
+| This skill's convention | How lint treats it |
+|---|---|
+| Object types as named parameters (no `{object}`) | `require-param` / `check-param-names` demand sub-property documentation for an `object` type, so writing an inline type literal aligns with lint (reinforced) |
+| Name a single object argument `params` | This skill's own convention (not lint-enforced) |
+| Always write `@returns` (including `{void}`) | `jsdoc/require-returns` fires only when a value is actually returned, so a function returning nothing passes lint without the tag → **this skill is stricter than lint** |
+| Attach a description to `@returns` (except `{void}`) | **`jsdoc/require-returns-description` is off**; lint does not require a description → **this skill is stricter than lint** (QA stance). The presence of `@returns` and its type are lint-enforced |
+| Add `@public` to entry points | Adding `@public` is a skill convention; `check-access` validates that the notation is correct |
+| Write array types as `Array<T>` (no `T[]`) | This skill's own convention (not lint-enforced) |
+| Avoid vague types (`object`/`Object`/`any`/`*`); write the most specific type and concrete generics | This skill's own convention (not lint-enforced). However, using `object`/`Object` as a type makes `require-param`/`check-param-names` demand sub-property documentation, so a detailed type literal aligns with lint (reinforced). See also the "object types as named parameters" row |
+| Prohibit `object`/`Object` (use `Record<string, *>`) | This skill's own convention (not lint-enforced). The reason is that `object` tolerates ambiguity including `null` |
+| Write the any type as `*` (no `any`) | This skill's own convention (not lint-enforced). `*` itself is not overused either; it is a last resort for when the type cannot be narrowed |
+| Do not write undefined type names (define custom types via `@typedef`/import) | `jsdoc/no-undefined-types` is **off** in the base default (overridden to `error` by this project's `eslint.config.js`). Built-in types and TS utility types (`Record`, etc.) count as defined. Enforced by this skill rather than relying on lint |
+| Do not write `undefined` as a type (use `null`) | This skill's own convention (not lint-enforced). `undefined` is a defined type, so `no-undefined-types` allows it. Exception: permitted when a third party requires it |
+| Do not place a delimiter after each chopped-down property | Inside a type literal, so lint does not parse it. This skill's own convention |
+| Write `@typedef` on at least three lines | **Lint-enforced** by `multiline-blocks` (`noSingleLineBlocks: true`); a single-line typedef errors |
+| One `@typedef` per block, separated by a blank line | This skill's own convention (not lint-enforced) |
+
+## Intentionally relaxed rules (off)
+
+These are `error` in the base (`@openreachtech/eslint-rules-default-jsdoc`) but are
+turned **off** by `jsdoc.js` in this project. This skill's patterns rely on their
+being off.
+
+- **`jsdoc/no-types` = off** → you **can write type annotations** such as
+  `@param {{ alpha: string }}` (the original recommendation forbids function type
+  annotations). This skill's way of writing types depends on it.
+- **`jsdoc/require-returns-description` = off** → lint does not require a description on
+  `@returns` (this skill still asks for one; see the table above).
+- **`jsdoc/require-description` = off** (unnecessary because `no-blank-blocks` exists) /
+  **`jsdoc/require-param-description` = off** → block descriptions and `@param`
+  descriptions are optional as far as lint is concerned.
+- **`jsdoc/require-example` = off** → `@example` is not required.
+- **`jsdoc/require-file-overview` = off** → `@file` / `@fileoverview` is not required.
+- **`jsdoc/check-tag-names` = off** → unknown / custom tags (e.g. `@note`) may be used.
+- **`jsdoc/match-description` / `require-description-complete-sentence` = off** →
+  description style, leading capital, and trailing period are not enforced.
+- **`jsdoc/valid-types` / `imports-as-dependencies` / `informative-docs` /
+  `text-escaping` = off** → strict type syntax validation, import-based type
+  dependency checks, and the like are not performed. Note that
+  `jsdoc/no-undefined-types` is off in the base default but is overridden to `error`
+  by this project's `eslint.config.js` (see the "do not write undefined type names"
+  row above).

--- a/kit/skills/core/hc-jsdoc/references/import-expression.md
+++ b/kit/skills/core/hc-jsdoc/references/import-expression.md
@@ -1,0 +1,97 @@
+# The `import()` Type Expression
+
+One of the two type-only-import styles. The established style in renchan backends, and the
+alternative in Furo / Nuxt apps — the examples below are frontend ones, but the expression
+itself is not frontend-specific. The other style is the [`@import`](import-tag.md) block tag.
+
+## Purpose
+
+`import('<module>').<Type>` is the inline import-type expression — a type-only import written **directly inside** a JSDoc annotation, with no separate import block. It is the alternative to the [`@import`](import-tag.md) block tag; both solve the same problem (referencing a type from another module in a JS-only Furo app).
+
+**Follow the repository's established style.** Some Furo apps use `import()` inline everywhere; others use `@import` blocks. If neither is established, prefer `@import`. Do not mix both styles for the same type.
+
+## Form
+
+`import('<module>').<ExportedName>` in any type position — `@type`, `@typedef`, `@param`, `@returns`, `@extends`. Generics and unions nest as usual:
+
+```js
+import('vue').Ref<HTMLFormElement | null>
+import('#app').NuxtError
+import('~/stores/customer.js').CustomerStore
+```
+
+For a module's **default export**, use `.default`:
+
+```js
+import('~/components/units/AppDialog.vue').default
+```
+
+Always include the filename extension (`.js`/`.vue`) in the module path — never omit it (`import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext.js')`, not `import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext')`).
+
+## Where it appears
+
+### Vue prop types
+
+Inline `import('vue').PropType<...>` on the prop's `type` field:
+
+```js
+props: {
+  data: {
+    /** @type {import('vue').PropType<NuxtError>} */
+    type: Object,
+    required: true,
+  },
+
+  items: {
+    /** @type {import('vue').PropType<Array<string>>} */
+    type: Array,
+    default: () => [],
+  },
+
+  onUpdate: {
+    /** @type {import('vue').PropType<(value: string) => void>} */
+    type: Function,
+    required: true,
+  },
+}
+```
+
+### Reactive declarations
+
+Above the `ref()` / `shallowRef()` / `reactive()` call:
+
+```js
+/** @type {import('vue').Ref<HTMLFormElement | null>} */
+const formRef = ref(null)
+
+/** @type {import('vue').ShallowRef<HTMLInputElement | null>} */
+const inputShallowRef = shallowRef(null)
+```
+
+### `@typedef` aliases
+
+An imported type can be aliased to a local name in one line, then used bare:
+
+```js
+/**
+ * @typedef {import('@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext.js').BaseFuroContextParams} ComponentContextParams
+ */
+
+/**
+ * @typedef {ComponentContextParams} ComponentContextFactoryParams
+ */
+```
+
+## Trade-offs vs `@import`
+
+| | `import('…')` inline | `@import` block |
+| --- | --- | --- |
+| Location | inside each annotation | one block at end of file / `<script>` |
+| Path | repeated at every use site | written once |
+| Best when | a type is used once or twice | a type recurs, or many types share a module |
+
+When the repository's convention is `@import`, promote a recurring inline `import('…')` to a named block rather than repeating the path.
+
+## Ambient globals: still no import
+
+As with `@import`, types declared under `declare global` in `types/*.d.ts` are used **unqualified** — `RequiredExcept`, `OptionalExcept`, `NullableExcept`, and the `schema.graphql.*`, `furo.*`, `GraphqlType.*` namespaces. Never wrap them in `import('…')`. See [[hf-nuxt]].

--- a/kit/skills/core/hc-jsdoc/references/import-tag.md
+++ b/kit/skills/core/hc-jsdoc/references/import-tag.md
@@ -1,0 +1,146 @@
+# The `@import` Tag
+
+One of the two type-only-import styles. The established style in Furo / Nuxt apps, so the
+examples below are frontend ones; the tag itself is not frontend-specific. The other style is
+the inline [`import('…')`](import-expression.md) expression, established in renchan backends.
+
+## Purpose
+
+`@import` is the JSDoc block tag for **type-only imports**. In a JavaScript-only Furo app there is no TypeScript syntax available, so `import type { … }` is not an option — `@import` is how a type declared in one module is made available for JSDoc annotations in another.
+
+Never use inline `import type`. The other type-only-import style is the inline `import('…')` expression ([import-expression](import-expression.md)); `@import` is the preferred one — import each type once at the bottom of the file and reference it by bare name. Don't mix the two styles for the same type.
+
+## Placement
+
+- `@import` blocks live at the **end of the file**, or at the **end of the `<script>` block** in a `.vue` file — after the code, alongside the `@typedef` blocks.
+- **One `@import` per JSDoc block, one source module per block.** Do not combine two `from '…'` sources in a single block.
+- Separate consecutive blocks with a blank line.
+
+```js
+/**
+ * @import {
+ *   Reactive,
+ * } from 'vue'
+ */
+
+/**
+ * @import {
+ *   useRouter,
+ * } from 'vue-router'
+ */
+
+/**
+ * @import {
+ *   BaseFuroContextParams,
+ * } from '@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext.js'
+ */
+```
+
+## Forms
+
+### Named import (braced, multi-line)
+
+The default form for named exports. Braces on their own lines, one symbol per line, **trailing comma** after every symbol — even a single one:
+
+```js
+/**
+ * @import {
+ *   Reactive,
+ *   ShallowRef,
+ * } from 'vue'
+ */
+```
+
+### Default import (one-line shorthand)
+
+For a module whose default export is the type you need (composables, GraphQL `*Payload` / `*Capsule` classes, module classes), the single-line form is idiomatic:
+
+```js
+/**
+ * @import useAppGraphqlClient from '~/composables/useAppGraphqlClient.js'
+ */
+
+/**
+ * @import SignOutMutationGraphqlCapsule from '~/app/graphql/client/mutations/signOut/SignOutMutationGraphqlCapsule.js'
+ */
+```
+
+### Default import via `default as` (braced)
+
+The braced equivalent of the shorthand, aliasing a module's default export to a local name. Reserve this form for single-file components (`.vue`, whose only export is the default):
+
+```js
+/**
+ * @import {
+ *   default as AppDialog,
+ * } from '~/components/units/AppDialog.vue'
+ */
+```
+
+Do **not** use the braced `default as` form for a class default export (`.js` composables, GraphQL `*Payload` / `*Capsule` classes, module classes) — use the one-line shorthand above instead:
+
+```js
+// Do not
+/**
+ * @import {
+ *   default as UpdateEmailMutationGraphqlCapsule,
+ * } from '~/app/graphql/client/mutations/updateEmail/UpdateEmailMutationGraphqlCapsule.js'
+ */
+
+// Do
+/**
+ * @import UpdateEmailMutationGraphqlCapsule from '~/app/graphql/client/mutations/updateEmail/UpdateEmailMutationGraphqlCapsule.js'
+ */
+```
+
+## Common source modules
+
+| Source | For |
+| --- | --- |
+| `'vue'` | `Reactive`, `Ref`, `ShallowRef`, `PropType`, `ComponentCustomProps`, … |
+| `'vue-router'` | `useRoute`, `useRouter` (consumed via `ReturnType<typeof …>`) |
+| `'#app'` | Nuxt types such as `NuxtError` |
+| `'@openreachtech/furo-nuxt'` / `'@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext.js'` | `BaseFuroContextParams`, furo base types |
+| `'~/composables/*.js'` | `use*` / `useApp*` composable defaults |
+| `'~/stores/*.js'` | `use*Store` return types (e.g. `CustomerStore`) |
+| `'~/app/graphql/client/**/*.js'` | GraphQL `*Payload` / `*Capsule` classes |
+| `'~/components/**/*.vue'` | component classes and their local typedefs |
+| `'./Component.vue'` / `'./index.vue'` | sibling local typedefs |
+
+Use the `~/` alias for repo-root paths and `./` for siblings — the same aliases Nuxt resolves at runtime.
+
+## Consuming imported types
+
+Once imported, a type is referenced **by its bare name** inside `@typedef`, `@type`, `@param`, `@extends`, etc. — no path qualifier:
+
+```js
+/** @type {Reactive<ErrorMessageHash>} */
+
+/**
+ * @typedef {BaseFuroContextParams & {
+ *   router: ReturnType<typeof useRouter>
+ *   customerStore: CustomerStore
+ *   dialogComponentShallowRef: ShallowRef<AppDialog | null>
+ * }} SignOutSubmitterContextParams
+ */
+```
+
+Sibling local typedefs (`ErrorMessageHash`, `ComponentProps`, `FormField`, …) are declared at the bottom of one `<script>`/file and re-imported across sibling files via `@import { ErrorMessageHash } from './Component.vue'`.
+
+## Relationship to the inline `import('…')` style
+
+The inline `import('…')` expression ([import-expression](import-expression.md)) is the alternative type-only-import style. In a repo standardized on `@import`, keep type imports in bottom-of-file blocks; if an inline `import('…')` creeps in for a one-off (typically a single Vue ref), prefer promoting it to a named `@import` block so the file stays in one style:
+
+```js
+// prefer this, with `Ref` from an `@import { Ref } from 'vue'` block…
+/** @type {Ref<ReturnType<typeof setTimeout> | null>} */
+const timeoutIdRef = ref(null)
+
+// …over the inline form in an `@import`-style file
+/** @type {import('vue').Ref<ReturnType<typeof setTimeout> | null>} */
+const timeoutIdRef = ref(null)
+```
+
+## Do not `@import` ambient globals
+
+Types declared under `declare global` in `types/*.d.ts` are used **unqualified, with no `@import`**: `RequiredExcept`, `OptionalExcept`, `NullableExcept`, and the `schema.graphql.*`, `furo.*`, and `GraphqlType.*` namespaces. Importing them is redundant. See the parent `hc-jsdoc` skill and [[hf-nuxt]].

--- a/kit/skills/core/hc-jsdoc/references/placement.md
+++ b/kit/skills/core/hc-jsdoc/references/placement.md
@@ -1,0 +1,46 @@
+# Placement & Naming
+
+Frontend (Vue / Nuxt) only. How a `@typedef` block itself is written (multi-line, one per
+block, blank line between blocks) is in the skill body; this file covers where the blocks go.
+
+## Placement rules
+
+- **`@typedef` blocks go at the END of the file** (after the class/exports), each in its own `/** ... */` comment. In `.vue`, at the end of `<script>`.
+- **`@import { ... } from '...'` type-only imports go at the bottom** of the file / end of `<script>`, one block per source module, multi-line with trailing commas. Never use inline `import type`.
+
+```js
+/**
+ * @import {
+ *   Reactive,
+ *   ShallowRef,
+ * } from 'vue'
+ */
+
+/**
+ * @import UpdateEmailMutationGraphqlCapsule from '~/app/graphql/client/mutations/updateEmail/UpdateEmailMutationGraphqlCapsule.js'
+ */
+```
+
+Sources: Vue built-ins from `'vue'`, Nuxt from `'#app'`, furo base params from `'@openreachtech/furo-nuxt/lib/contexts/BaseFuroContext.js'`, sibling local types from `'./Component.vue'` / `'./index.vue'`.
+
+## Inline `@type` on reactive declarations
+
+Put `@type {Ref<...>}` / `@type {Reactive<...>}` / `@type {ShallowRef<...>}` directly above the `ref()`/`reactive()`/`shallowRef()` call:
+
+```js
+/** @type {Reactive<ErrorMessageHash>} */
+const errorMessageHashReactive = reactive({
+  updateEmail: null,
+  verifyEmail: null,
+})
+
+/** @type {Ref<ReturnType<typeof setTimeout> | null>} */
+const timeoutIdRef = ref(null)
+```
+
+Here `Reactive`/`Ref` are pulled in once via a bottom-of-file `@import { Reactive, Ref } from 'vue'` block (the preferred style; see [import-tag](import-tag.md)). In a repo that uses the inline style instead, write `@type {import('vue').Ref<...>}` ([import-expression](import-expression.md)).
+
+## Naming
+
+- Params typedef: `<ClassName>Params`; factory params: `<ClassName>FactoryParams`.
+- Local component typedefs (`ErrorMessageHash`, `SuccessMessageHash`, `UserInterfaceState`, `FormField`, `ComponentProps`) defined at the end of the `<script>`/file and re-imported across sibling files via `@import ... from './Component.vue'`.

--- a/kit/skills/core/hc-jsdoc/references/vue-props-and-globals.md
+++ b/kit/skills/core/hc-jsdoc/references/vue-props-and-globals.md
@@ -1,0 +1,35 @@
+# Vue Props & Ambient Globals
+
+Frontend (Vue / Nuxt) only. The function and method annotation rules these examples follow
+(single-object `@param`, always-present `@returns` with a description) are in the skill body.
+
+## Vue prop types
+
+Inline `@type {PropType<...>}` on the prop's `type` field:
+
+```js
+props: {
+  error: {
+    /** @type {PropType<NuxtError>} */
+    type: Object,
+    required: true,
+  },
+}
+```
+
+`String` is a special case, we must use type cast on the String object:
+
+```js
+props: {
+  type: {
+    type: /** @type {PropType<MessageType>} */ (String),
+    required: true,
+  },
+}
+```
+
+See [[hf-nuxt]].
+
+## Ambient global helpers (no import needed)
+
+`RequiredExcept`, `OptionalExcept`, `NullableExcept` are declared in `types/global.d.ts` under `declare global`, so they're used **unqualified** in JSDoc with no `@import`. Same for `schema.graphql.*` ([[hf-graphql]]), `furo.*`, and `GraphqlType.*` ([[hf-nuxt]]).

--- a/kit/skills/core/hc-license/SKILL.md
+++ b/kit/skills/core/hc-license/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: hc-license
+description: "Write and update LICENSE files for projects. Use this skill whenever the user asks to create, update or delete a LICENSE file."
+---
+
+# License Skill
+
+When creating or updating the LICENSE file and the README's license notation, follow the rules below.
+
+**Behavior is determined by the `license` field in `package.json`** (if the user explicitly specifies a different license, prioritize that, and update `package.json` accordingly if needed).
+
+## Workflow
+
+1. Read `license` in `package.json`.
+2. Adjust the `./LICENSE` file according to its value (see below).
+3. Align the license sections of `README.md` (default language) and each `README.xx.md` per language.
+   The wording and templates for the license section are governed by the "License" convention in the **README convention**.
+
+## `UNLICENSED`
+
+Denotes private/restricted distribution.
+
+- If `./LICENSE` exists, **delete it** (if it does not exist, do nothing).
+- The body of the license section in `README.md` / `README.xx.md` should be the single word `UNLICENSED`.
+
+## `Apache-2.0`
+
+Copy the full text of [templates/Apache-2.0](./templates/Apache-2.0) as-is into `./LICENSE` (do not modify the body).
+
+- The **`[yyyy]`** in the trailing APPENDIX should match the year in the README's Copyright section (`© <year> ...`).
+- The **`[name of copyright owner]`** in the trailing APPENDIX should be replaced with `author` from `package.json` (e.g., `Open Reach Tech Inc.`).
+
+The license section of `README.md` / `README.xx.md` should contain wording that links to `./LICENSE`
+(the template is governed by the "License" convention in the README convention).
+
+## `MIT`
+
+Copy the full text of [templates/MIT](./templates/MIT) into `./LICENSE`, replacing the placeholders.
+
+- **`[full name]`** should be replaced with `author` from `package.json` (e.g., `Open Reach Tech Inc.`).
+- **`[year]`** should match the README's Copyright section (`© <year> ...`).
+
+The license section of `README.md` / `README.xx.md` should contain wording that links to `./LICENSE`
+(the template is governed by the "License" convention in the README convention).
+
+## Others
+
+When the license is none of `UNLICENSED`, `Apache-2.0`, or `MIT`, prompt the user to confirm what to do with the `./LICENSE` file.

--- a/kit/skills/core/hc-license/templates/Apache-2.0
+++ b/kit/skills/core/hc-license/templates/Apache-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kit/skills/core/hc-license/templates/MIT
+++ b/kit/skills/core/hc-license/templates/MIT
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) [year] [full name]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/kit/skills/core/hc-methods/SKILL.md
+++ b/kit/skills/core/hc-methods/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: hc-methods
+description: "Conventions for class method definitions. Covers named arguments, passing properties into private methods, factory methods, and related policies."
+---
+
+# Classes: Members / Methods
+
+This summarizes conventions related to class method definitions.
+
+## Arguments should be a single named-argument object
+
+- With some exceptions, the arguments of a defined method should in principle be received as a single object, using
+  named arguments (destructuring assignment).
+- Break each argument onto its own line and chop it down (one property per line).
+
+```javascript
+// NG: positional arguments
+generate (length) {
+  // ...
+}
+
+// OK: single named-argument object, chopped down
+generate ({
+  length,
+}) {
+  // ...
+}
+```
+
+### Exception: binding (inflator) methods pass arguments flat
+
+- Binding (inflator) methods do not use a named-argument object; they receive **the arguments to pass, flat**.
+- An inflator method is a static method that binds the class passed as an argument and returns a memoized derived subclass (following the naming convention described later, such as `.use()` / `.of()` / `.to()`).
+- Basically it receives **a single argument**. Only use multiple/array arguments when dealing with variadic or array input.
+  - Single argument: `use(ConstraintCtor)` / `as(Schema)` / `toKey(MessageKeyCtor)` / `toValue(MessageValueCtor)`
+  - Variadic: `of(...Ctors)`
+  - Single array: `from(Ctors)` (it is standard practice for `from` to delegate to `of`)
+
+```javascript
+// NG: named-argument object
+static use ({
+  ConstraintCtor,
+}) {
+  // ...
+}
+
+// OK: flat single argument
+static use (ConstraintCtor) {
+  // ...
+}
+
+// OK: variadic / array arguments
+static of (...Ctors) {
+  // ...
+}
+
+static from (Ctors) {
+  return this.of(...Ctors)
+}
+```
+
+- Reason: this is so that calls read **declaratively**, as in `Document.as(bindingSchema)` or `UnionScalar.of(A, B)`. Wrapping them in a named-argument object would undermine this declarative feel.
+
+#### Naming convention (short, preposition-like names)
+
+- Inflator methods should be given short, preposition-like names (so that `Receiver.word(binding)` reads declaratively). Examples: `.as()` / `.use()` / `.of()` / `.to()`, etc.
+- These are only representative examples, not the full vocabulary. The full vocabulary — the semantics of each word, its arguments, the forward vs. graft distinction, and how `.toKey()` / `.toValue()` are used — is owned by the inflator-methods convention as its single source of truth; it is not duplicated here.
+
+## Do not pass properties directly to private methods
+
+- Unless there is a specific reason, do not pass an (instance) property directly as an argument to a private /
+  internal method.
+- Internal methods should reference the properties they need directly from `this`. This avoids passing arguments around and preserves encapsulation.
+- If a piece of logic needs a property passed as an argument, that is a sign that "it should be a static method rather than an instance method."
+- However, making it static would remove the point of instantiation, so the correct approach is for instance methods to reference `this` with no arguments.
+
+```javascript
+// NG: passing your own property into an internal method
+buildKey () {
+  return this.formatName({
+    name: this.name,
+  })
+}
+
+// OK: the internal method references `this` directly
+buildKey () {
+  return this.formatName()
+}
+
+formatName () {
+  return this.name.toUpperCase()
+}
+```
+
+## Factory methods must be defined without exception
+
+- Class definitions must define a factory method without exception.
+- Unless a class is inheriting, every class definition must define `static create (...)`.
+  (When inheriting, the parent class's `create` is inherited, so it doesn't need to be redefined.)
+- The parameters of `static create (...)` should define what is needed to construct the arguments passed to the constructor.
+- Factory methods should, unless there is a specific reason not to, be implemented as **static methods**
+  (`static create (...)`).
+
+### Division of responsibility between the constructor and `static create (...)`
+
+- The constructor should receive required arguments (e.g. `{ characters }`). It should not have default values.
+- Applying default values for arguments is the responsibility of `static create (...)`.
+
+### Variations should be distinguished by suffix
+
+- When variations of `.create(...)` or `.createAsync(...)` are needed, distinguish them with a suffix.
+  (e.g. `.createAsAlpha()` / `.createWithBeta()`)
+
+### Placement order
+
+- `static create (...)` should be placed immediately after the constructor.
+- If `static createAsync (...)` is defined, it should in principle be placed immediately after `.create(...)`.
+
+### JSDoc format
+
+- Unless there is a specific reason otherwise, the JSDoc of a factory method must follow the format below without exception.
+  (Replace `ThisClass` with the name of the class being defined.)
+
+```javascript
+/**
+ * Factory method.
+ *
+ * @template {X extends typeof ThisClass ? X : never} T, X
+ * @param {...} [params] - Parameters for the factory method.
+ * @returns {InstanceType<T>} Instance of this class.
+ * @this {T}
+ * @public
+ */
+```
+
+- Since the factory method is an entry point called from outside, it is annotated with `@public`.
+
+### Instantiation
+
+- Within `.create(...)`, do not call `new` using the class name. Instantiate with `new this(...)`.
+  (Using `this` ensures that even when called from an inheriting subclass, an instance of that subclass is created.)
+- Since every defined class always has a factory method defined, whenever depending on another class, always instantiate it via its factory method (`.create(...)`).
+- Consequently, the form `new Sample(...)` against a defined class never appears outside test files.
+  (The exception is `new this(...)` inside `.create(...)`. This creates an instance of the class itself using `this`, not the class name.)
+
+```javascript
+// NG
+static create (...) {
+  return new RandomTextGenerator({ characters })
+}
+
+// OK
+static create (...) {
+  return new this({ characters })
+}
+```
+
+#### Exception: direct `new` for built-in classes and third-party modules
+
+- The exceptions where a direct `new` expression is allowed without going through a factory method (JavaScript built-in classes, DTO-like third-party modules, and the DTO whitelist) are collected in [references/instantiation.md](./references/instantiation.md).
+
+#### `XxxxFactory` class and the two-stage separation
+
+- The `XxxxFactory` pattern for consolidating creation of a frequently used class (with the `BaseFactory` example), and the intent behind the selection (`.get:TargetCtor`) / instantiation (`.createTarget()`) two-stage separation, are collected in [references/factory-class.md](./references/factory-class.md).
+
+### Instantiation of a dependency class should go through a factory method
+
+- Do not directly create a dependency class in a default argument of `.create(...)`, etc. That is, do not directly write either `new Dependency(...)` (a `new` expression) or `Dependency.create(...)` (calling the dependency class's factory method). Extract the creation of the dependency class into a dedicated factory method (e.g. `this.createExternalApiClient()`) and go through it.
+- Unless there is a specific reason otherwise, the name of the dedicated factory method should basically be "`create` + class name" (e.g. `ExternalApiClient` → `createExternalApiClient`).
+
+```javascript
+// NG: directly instantiating a dependency class
+static create ({
+  externalApiClient = ExternalApiClient.create({ env }),
+} = {}) {
+  // ...
+}
+
+// OK: go through a factory method
+static create ({
+  externalApiClient = this.createExternalApiClient(),
+} = {}) {
+  // ...
+}
+```
+
+Reason:
+
+- **Patching/overriding is easy**: if a dependency has a bug and you need to apply an emergency patch in a subclass, you only need to override the factory method in the subclass, without changing the call sites. If the dependency were instantiated directly, every call site would need to explicitly pass the patched instance.
+- **Encapsulation of the dependency**: the caller's concern is the class in question, not its internal dependencies. The factory method hides the dependency relationship inside the class, lowering coupling.
+- **Testing/DI is easy**: you can inject a mock via an argument, or swap the factory's return value with `jest.spyOn(ThisClass, 'createExternalApiClient')`, and test with the same call form as production.
+- The factory method is lightweight DI (Dependency Injection), achieving, without a DI container: production = creation of the real dependency / testing = swap / hotfix = swap to a patched dependency.
+
+### When asynchronous creation is needed, define `.createAsync(...)`
+
+- The convention for `.createAsync(...)` when the constructor arguments need to be generated asynchronously (delegation to `.create(...)`, JSDoc, and a complete example) is collected in [references/create-async.md](./references/create-async.md).

--- a/kit/skills/core/hc-methods/references/create-async.md
+++ b/kit/skills/core/hc-methods/references/create-async.md
@@ -1,0 +1,68 @@
+# Asynchronous creation `.createAsync(...)`
+
+This covers the convention for `.createAsync(...)`, defined when the arguments passed to the constructor need to be generated via asynchronous processing. Referenced from the method-definition convention itself (`SKILL.md`).
+
+- When the arguments passed to the constructor need to be generated via asynchronous processing, define `static createAsync (...)`.
+- The JSDoc of `.createAsync(...)` should conform to that of `.create(...)` (the return value becomes `Promise<InstanceType<T>>`).
+- Calling `new this(...)` directly from `.createAsync(...)` is prohibited. In principle, `.createAsync(...)` should
+  return the return value of `.create(...)`.
+
+```javascript
+// NG: calling new this(...) directly from createAsync
+static async createAsync () {
+  const characters = await this.resolveCharacters()
+
+  return new this({ // ❌️
+    characters,
+  })
+}
+
+// OK: prepare the arguments asynchronously, then return the return value of create()
+static async createAsync () {
+  const characters = await this.resolveCharacters()
+
+  return this.create({
+    characters,
+  })
+}
+```
+
+Example:
+
+```javascript
+export default class RandomTextGenerator {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   characters: string
+   * }} params - Parameters.
+   */
+  constructor ({
+    characters,
+  }) {
+    this.characters = characters
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof RandomTextGenerator ? X : never} T, X
+   * @param {{
+   *   characters?: string
+   * }} [params] - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    characters = this.DEFAULT_CHARACTERS,
+  } = {}) {
+    return /** @type {InstanceType<T>} */ (
+      new this({
+        characters,
+      })
+    )
+  }
+}
+```

--- a/kit/skills/core/hc-methods/references/factory-class.md
+++ b/kit/skills/core/hc-methods/references/factory-class.md
@@ -1,0 +1,66 @@
+# `XxxxFactory` class and the two-stage separation
+
+This covers the `XxxxFactory` pattern, which consolidates creation of a frequently used dependency class into one place, and the intent behind separating its creation into "selection (`.get:TargetCtor`)" and "instantiation (`.createTarget()`)." Referenced from the method-definition convention itself (`SKILL.md`).
+
+## Example of an `XxxxFactory` class
+
+- Consolidate creation of a frequently used class into one place, confining the `new` expression to a factory class. Inherit from the common base `BaseFactory`, and have the concrete class fix the target class solely by overriding `.get:TargetCtor`.
+
+```javascript
+/**
+ * Base class of factories.
+ *
+ * @abstract
+ */
+class BaseFactory {
+  constructor ({
+    TargetCtor,
+  }) {
+    this.TargetCtor = TargetCtor
+  }
+
+  static create ({
+    TargetCtor = this.TargetCtor,
+  } = {}) {
+    return new this({
+      TargetCtor,
+    })
+  }
+
+  static get TargetCtor () {
+    throw new Error(`${this.name}.get:TargetCtor must be inherited`)
+  }
+
+  createInstance (...args) {
+    return new this.TargetCtor(...args)
+  }
+}
+```
+
+```javascript
+import SampleClient from './SampleClient.js'
+
+class SampleFactory extends BaseFactory {
+  /** @override */
+  static get TargetCtor () {
+    return SampleClient
+  }
+
+  createSampleClient ({
+    options,
+  }) {
+    return this.createInstance(options)
+  }
+}
+```
+
+- `#TargetCtor` holds the constructor of the target class, and the `new` expression is consolidated into a single point, `BaseFactory#createInstance()`.
+- `SampleFactory` does not redefine `create`; it inherits it from the parent, and fixes the target class solely by overriding `.get:TargetCtor`. This means swapping implementations (test doubles, patches) requires only overriding the getter.
+
+## Intent behind the two-stage separation (`.get:TargetCtor` and `.createTarget()`)
+
+- The creation of a delegate class is separated into two stages: **`.get:TargetCtor` (which class = selection)** and **`.createTarget()` (how to create it = instantiation)**. These are orthogonal, independent concerns, each serving as its own override / test seam.
+- **`.get:TargetCtor` (the selection seam)**: consolidates "which class" the delegate target is into a single point. Since it is resolved via `this`, a subclass overriding it swaps the target class (polymorphism). In tests, `jest.spyOn(Factory, 'TargetCtor', 'get').mockReturnValue(StubClient)` swaps out **only the class**.
+- **`.createTarget()` (the instantiation seam)**: the **single place** where `new this.TargetCtor(...)` is executed. Building and formatting arguments is also confined here. When you want to change "how it's created," you only need to override this method.
+- **Why not merge them**: merging them into a single method would mean that even a "I just want to swap the class" change forces you to rewrite the creation logic as well, and vice versa. Keeping them separate makes the override points independent, each with a single responsibility. The `new` expression is confined to the single point of `.createTarget()`, and the class reference to the single point of `.get:TargetCtor`, isolating the volatile "which class" decision into the getter.
+- This achieves, without a DI container (lightweight DI): production = real class creation / testing = class swap (getter) or creation swap (`.createTarget()`) / hotfix = overriding either one.

--- a/kit/skills/core/hc-methods/references/instantiation.md
+++ b/kit/skills/core/hc-methods/references/instantiation.md
@@ -1,0 +1,58 @@
+# Exceptions to direct `new` without a factory method
+
+This covers the exceptions where a direct `new` expression is allowed without going through a factory method (`.create(...)`) — JavaScript built-in classes and DTO-like third-party modules — along with the DTO whitelist. Referenced from the method-definition convention itself (`SKILL.md`).
+
+## Exception: JavaScript built-in classes
+
+- JavaScript's built-in classes (`Date` / `WeakMap` / `Set` / `RegExp` / `Error`, etc.) are not subject to the `new`-expression restriction. They may be freely instantiated directly with `new`, without going through a dedicated factory method.
+  - `Map` is the exception. Even though it is a built-in class, `Map` is entirely prohibited and must not be instantiated directly with `new` either (see "`Map` is prohibited; `WeakMap` is free" in the property-definition convention). Use `WeakMap` when association is needed.
+- These are neither classes defined by this codebase nor its dependency classes, and they have no `.create(...)` factory method, so they fall outside this convention.
+
+```javascript
+// OK: built-in classes may be instantiated directly with new
+const date = new Date(value)
+const pattern = new RegExp(source, 'ug')
+
+throw new Error(`${this.constructor.name}#normalizeValue() must be inherited`)
+```
+
+## Third-party modules
+
+- Third-party modules are subject to the factory-method `new`-expression restriction **depending on their intended purpose**.
+
+1. Modules that behave as **DTOs** (e.g. `BigNumber`) are treated the same as built-in classes. They may be freely instantiated directly with `new`, without going through a dedicated factory method.
+   - However, writing a direct `new` expression is allowed **only if the module does not provide a factory method** such as `Model.build()` / `Sample.create()`. If a factory method is provided, use that factory method instead of a `new` expression.
+   - When it is hard to determine whether something is DTO-like, **define a factory method instead of asking a
+     human**.
+   - If the same class is instantiated **frequently across multiple classes**, introduce a new `XxxxFactory` class. It holds the target class's constructor as a property and **performs the `new` expression through that factory class**. If a common base `BaseFactory` class exists, use it (via inheritance); if not, provide a **generic implementation** that doesn't depend on a specific class.
+2. For **delegate-style functional classes** (classes held in a property and used by delegating their functionality), basically implement a factory method to go through (following "instantiation of a dependency class should go through a factory method").
+3. Delegate-style functional classes require a factory method **regardless of whether they are created on the fly within an instance method**. Even when created temporarily within a method, do not `new` them directly; go through a dedicated factory method (e.g. `this.createExternalApiClient()`).
+
+- Note that this principle (2)(3) is **not limited to third-party modules**. Even for classes defined within the application, if the structure delegates use of an instance, instantiation via a factory method is equally required.
+
+```javascript
+// OK (1): DTO-like modules may be instantiated directly with new
+const amount = new BigNumber(value)
+
+// NG (2)(3): directly `new`-ing a delegate-style functional class (not allowed even when created on the fly)
+sendRequest () {
+  const client = new ExternalApiClient({ env })
+
+  return client.send()
+}
+
+// OK (2)(3): go through a factory method
+sendRequest () {
+  const client = this.createExternalApiClient()
+
+  return client.send()
+}
+```
+
+## DTO whitelist
+
+- The following third-party modules are considered DTOs and may be freely instantiated directly with `new` (treatment (1)). Add to the whitelist as needed.
+
+| module | class |
+| :-- | :-- |
+| bignumber.js | `BigNumber` |

--- a/kit/skills/core/hc-modules-exports/SKILL.md
+++ b/kit/skills/core/hc-modules-exports/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: hc-modules-exports
+description: "Conventions for module exports. Don't define files that merely named-export a function; define a class per responsibility."
+---
+
+# Modules: Exports
+
+Conventions related to module exports.
+
+## Don't define files that merely named-export a function
+
+- Don't define a file whose only purpose is to named-export a function.
+- If each function has a single responsibility, defining a class one by one is the correct approach.
+
+```javascript
+// NG: a file that merely named-exports a function
+export function normalizeColor ({
+  value,
+}) {
+  // ...
+}
+
+// OK: define a class per responsibility
+export default class ColorNormalizer {
+  // ...
+}
+```

--- a/kit/skills/core/hc-modules-imports/SKILL.md
+++ b/kit/skills/core/hc-modules-imports/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: hc-modules-imports
+description: "Conventions for module imports. Group imports at the top of the file, ordered from farthest to nearest to application development."
+---
+
+# Modules: Imports
+
+Conventions related to module imports.
+
+## Group imports at the top of the file
+
+- Group all imports together at the top of the file.
+- Do not place assignment statements between imports.
+
+## Import order
+
+- Order imports "from farthest to nearest to application development".
+- The order is as follows.
+
+1. JavaScript native modules
+2. third party dependency modules
+3. ORT modules
+4. application modules
+5. constants
+
+```javascript
+// JavaScript native modules
+import fs from 'node:fs'
+
+// third party dependency modules
+import express from 'express'
+
+// ORT modules
+import BaseClass from '@openreach/base'
+
+// application modules
+import ColorNormalizer from '../lib/ColorNormalizer.js'
+
+// constants
+import COLOR from '../constants/COLOR.js'
+```

--- a/kit/skills/core/hc-naming/SKILL.md
+++ b/kit/skills/core/hc-naming/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: hc-naming
+description: "Naming conventions. Covers naming of classes, methods, properties, and accessors, datetime suffixes (`At` / `On`, plus `From` / `To` for ranges), criteria for abbreviations, American spelling, forbidden words, and the prohibition of non-ASCII characters."
+---
+
+# Shared: Naming
+
+Summarizes naming conventions.
+
+## Class names
+
+- Class names are written in UpperCamelCase.
+- Use the singular form of a noun.
+- Reason: if a plural noun is used, you cannot define a variable name for "an array holding instances of that class."
+  This is because there is no way to express "the plural of instances of a plural-named class."
+- When no specific class name is dictated, name the class to describe the logic it encapsulates.
+
+```javascript
+// NG
+class Users {}
+const users = [new Users(), new Users()] // Cannot express "plural of instances of a plural class"
+
+// OK
+class User {}
+const users = [new User(), new User()]
+```
+
+## Name variables and properties holding arrays as plural nouns
+
+- A variable or property that holds an array (a value with multiple elements) is always named with "the plural form of the noun denoting its element."
+- This is the counterpart of the "class names are singular" rule (see "Class names"). If the element's class is the singular `User`, its array is the plural `users`.
+- Do not express plurality with a `List` suffix (see `list` in [references/prohibited-words.md](./references/prohibited-words.md)).
+
+```javascript
+// NG: named singular despite holding an array / expressing plurality with a List suffix
+const user = users.filter(it => it.enabled) // holds an array yet named singular
+const paymentList = payments.filter(it => it.completed)
+
+// OK: plural form of the noun denoting the element
+const enabledUsers = users.filter(it => it.enabled)
+const completedPayments = payments.filter(it => it.completed)
+```
+
+## The `item` parameter of higher-order function callbacks
+
+- For a function passed to a higher-order function, use `it` as the parameter name for receiving each item.
+- If a higher-order function is called inside another higher-order function, using `it` for the inner item too would be confusing, so name the inner item's parameter according to the meaning of its value.
+- The first-layer callback argument should basically use `(it, index, array) => ...`.
+- For `reduce()` and `reduceRight()`, name the first argument (the accumulator) appropriately based on the meaning of the value being accumulated (e.g. `total` for a running sum).
+
+```javascript
+// OK: item parameter is it
+const ids = samples
+  .filter(it => it.enabled)
+  .map(it => it.id)
+
+// OK: name the inner nested item by meaning (outer it / inner user, etc.)
+const names = teams
+  .flatMap(it =>
+    it.members.map(user => user.name)
+  )
+
+// OK: name the reduce accumulator by meaning (total for a running sum)
+const total = prices
+  .reduce((total, it) => total + it.amount, 0)
+```
+
+## Naming abstract classes and derived classes
+
+- Prefix abstract classes with `Base~`.
+- When extending `BaseSample` for a specific application, add `App` as in `BaseAppSample`.
+- The `Base~` and `App~` in `BaseAppSample` are called "super prefixes."
+- When naming a derived class, remove the super prefix (`Base~` / `App~`), keep the suffix, and replace it with a distinguishing prefix.
+
+```javascript
+// Abstract class
+class BaseSample {}
+
+// Abstract class extended for the application
+class BaseAppSample extends BaseSample {}
+
+// Derived classes (super prefix removed and replaced with a distinguishing prefix; suffix "Sample" is kept)
+class AlphaSample extends BaseSample {}
+class BetaSample extends BaseAppSample {}
+```
+
+## Method names are "predicates," not "complete sentences"
+
+- A method call `receiver.method()` has a structure resembling a sentence: "subject (receiver) + predicate (method)."
+- Therefore, a method name should be named as a **predicate** with the receiver as the subject, not as a "complete sentence with both subject and predicate."
+
+```javascript
+// NG: named as a complete sentence (object.isStatusValid() reads as "object is status valid?", which is unnatural)
+isStatusValid () {
+  return this.status !== null
+}
+
+// OK: named as a predicate (object.isValidStatus() reads as "object is valid status")
+isValidStatus () {
+  return this.status !== null
+}
+```
+
+### Property syntax and "messages to the receiver"
+
+- In the property syntax `object.alpha`, each token is called: `object` = receiver, `.` = dot operator, `alpha` = property.
+- A method is a property in the broad sense. It is a property whose value is a function, invoked with `()`; `object.methodName` is property access, and `object.methodName()` is the notation for executing that value "as a function."
+- Hence a method call is a message where "receiver = subject, method name = predicate," and follows a sentence-like structure such as `object.doSomething()` (object does something) / `object.isValid()` (object is valid).
+- `#isStatusValid()` is wrong because it treats the method name as "a complete sentence with subject and predicate combined (Is status valid?)." Calling it via a receiver reads as "object is status valid?", which is unnatural. Name it with only the predicate (`#isValidStatus()` → "object is valid status").
+
+### Method names start with a verb
+
+- Since a method name is a predicate, it is natural, from an English grammar standpoint, for it to "start with a verb" (e.g. `#hasEntity()` / `#findUserProfile()`).
+- It may also start with an auxiliary verb (e.g. `#canFindEntity()` / `#shouldHaveFulfilledInput()`).
+
+### Third-person singular verb → convention that the return value is boolean
+
+- Starting a verb in the third-person singular form (or with an auxiliary verb) carries the convention that "the return value is boolean" (`is...()` / `has...()` / `can...()` / `should...()`, etc.).
+- This originates from Java (Sun Microsystems) coding conventions from the late 1990s, which spread to later languages.
+
+```javascript
+object.isValid() // boolean
+object.containsInvalidTag() // boolean (third-person singular contains → boolean)
+```
+
+- This originates from Java conventions established by Sun Microsystems in the late 1990s (methods returning boolean start with a third-person singular verb or an auxiliary verb: `is...()` / `has...()` / `can...()` / `should...()`, etc.), which spread as a standard to later languages.
+- Conversely, if a predicate is named correctly, the return type can be inferred even without JSDoc (e.g. `object.lovesWithoutConditions()` → readable as boolean because it's a third-person singular verb).
+
+## Criteria for using abbreviations
+
+- The criteria and whitelist (shared between JS and CSS) for which abbreviations may be used are collected in [references/abbreviations.md](./references/abbreviations.md).
+
+## Do not use non-ASCII characters in names
+
+- Do not use non-ASCII characters in variable names, class names, member names, etc.
+
+```javascript
+// Never use
+class 😂 {
+  取得 () {
+    return null
+  }
+}
+```
+
+## Avoid single-word class names wherever possible
+
+- Avoid single-word class names wherever possible; use a compound name containing two or more words.
+- If this is pointed out in a review, always change it to a compound word to save discussion time.
+
+## Use American spelling
+
+- The correspondence between American and British spellings is collected in [references/spelling.md](./references/spelling.md).
+
+## Prohibited words and redundant compound words
+
+- Words that must not be used in naming (as prefixes/suffixes) and the redundant compound words that contain them are collected in [references/prohibited-words.md](./references/prohibited-words.md).
+
+## Property names
+
+- Property names are, in principle, nouns. They are acceptable if they are clear.
+- Array properties should be pluralized (`#payments` correct / `#paymentList` incorrect). See "Name variables and properties holding arrays as plural nouns."
+
+## Datetime suffixes: `At` for an instant, `On` for a date
+
+- A value that carries a **time of day** ends with `At` (`modifiedAt`, `trashedAt`, `expiredAt`).
+- A value whose meaning stops at the **calendar date** ends with `On` (`billedOn`, `dueOn`).
+- A range keeps the suffix and appends `From` / `To` (`modifiedAtFrom` / `modifiedAtTo`, `billedOnFrom` / `billedOnTo`).
+- Reason: the suffix is the only place the granularity is stated. Dropping it (`modifiedFrom`) forces every reader to open the column definition to learn whether a time component exists, and a date-only value silently compared against an instant is off by up to a day — a bug that only appears near midnight.
+- `From` / `To` mark **the two ends of a range**. A single value meaning "in effect from this moment" is not a range end; name it for the instant it holds (`effectiveAt`), not `effectiveFrom`.
+
+```javascript
+// NG
+const modifiedFrom = ...  // does the value carry a time of day? the name does not say
+const billed = ...        // a date or an instant?
+const effectiveFrom = ... // a single instant named as if it were a range end
+
+// OK
+const modifiedAt = ...
+const billedOn = ...
+const effectiveAt = ...
+const modifiedAtFrom = ... // range lower bound, suffix kept
+const modifiedAtTo = ...   // range upper bound
+```
+
+## Method names
+
+- Method/function names should basically start with the base (present tense) form of a verb (e.g. `findUsers()` / `deleteUsers()`).
+- Starting with a particle (such as a preposition) is allowed, but should be avoided when used alone wherever possible (`fromOpenedAt()` correct / `from()` incorrect).
+  - Exception: inflator methods adopt preposition-like short names as their canonical vocabulary (`.from()` / `.of()` / `.by()`, etc.). See the inflator-methods convention for details.
+- A single-word name for an instance method is basically prohibited (`#load()` doesn't reveal what is being loaded; use `#loadCardNumbers()`).
+- For static methods, since the class name supplements the context, a single-word name is exceptionally allowed (`CardNumbersLoader.load()`).
+- For a method name that serves as an entry point, interpret it as a transitive verb wherever possible and give it an object (e.g. for `ChunkBuilder`, use `#buildChunks()` instead of `#build()`).
+  - Reason: if the instance is held in a short-scoped variable or property, the context supplementation from the class name is lost. If held as in `const builder = ChunkBuilder.create()`, then `builder.build()` doesn't reveal what is being built. Including the object, as in `builder.buildChunks()`, conveys it to the reader.
+
+## Accessors (getter / setter)
+
+- Getter names should in principle be nouns.
+- Naming a getter with a "boolean method name" that starts with a third-person-singular verb or an auxiliary verb is also permitted.
+- Since setters are prohibited, there is no naming rule for them (see the accessor-definition convention).
+
+## Method name verbs (choosing among highly abstract verbs)
+
+- How to choose among highly abstract verbs (creation `create` / `generate` / `build`, retrieval `find` / `fetch` / `extract`, update `save` / `send` / `set`) is collected in [references/verbs.md](./references/verbs.md).
+
+## Contrasting terms
+
+- The fixed pairs to use for variable/member names with opposite meanings are collected in [references/antonyms.md](./references/antonyms.md).

--- a/kit/skills/core/hc-naming/references/abbreviations.md
+++ b/kit/skills/core/hc-naming/references/abbreviations.md
@@ -1,0 +1,35 @@
+# Criteria for using abbreviations
+
+This lists the criteria and whitelist for which abbreviations may be used in naming. Referenced from the naming convention itself (`SKILL.md`). This abbreviation whitelist is shared between JavaScript and CSS and is not managed in two places (abbreviations in CSS custom property names also follow this criteria/whitelist).
+
+- For variable names, class names, method names, etc., any abbreviation is prohibited except those "generally recognized widely, not just in programming."
+- Any abbreviation not listed in the whitelist below is prohibited. The whitelist may be expanded as needed.
+
+## Whitelist
+
+| abbreviation | original word | note |
+| :-- | :-- | :-- |
+| admin | administrator | general knowledge |
+| app | application | general knowledge |
+| config | configuration | general knowledge |
+| enum | enumerate | - |
+| env | environment | general knowledge |
+| id | identity | general knowledge |
+| init | initialize | - |
+| int | integer | general knowledge |
+| max | maximum | general knowledge |
+| min | minimum | general knowledge |
+| nav | navigation | general knowledge |
+| sin | sine | - |
+| cos | cosine | - |
+| tan | tangent | - |
+| Ctor | constructor | `constructor` is JavaScript reserved word |
+| noop | no operation | for description |
+| faq | acronym of "frequently asked questions" | - |
+| func | function | Reluctantly allowed since `function` is a reserved word. Prefer a name that explicitly states the functionality wherever possible. `fn` / `f` are not allowed |
+
+Supplementary notes (abbreviations):
+
+- Only two kinds are permitted: "abbreviations universally used in society" or "abbreviations conventionally used in programming for many years" (e.g. `char`, `exec`, `eval`, etc. are also conventionally allowed).
+- The following abbreviations are prohibited: `acc`, `arr`, `avg`, `auth`, `btn`, `cate`, `cfg`, `cnt`, `cond`, `ctx`, `e`, `err`, `ev`, `ex`, `fmt`, `msg`, `no`, `num`, `prod`, `tx`, `tz`, and so on.
+- Even if an abbreviation is used within an external module, that is not a reason to use the abbreviation yourself (e.g. do not imitate Sequelize's `msg` or Express's `req` / `res`).

--- a/kit/skills/core/hc-naming/references/antonyms.md
+++ b/kit/skills/core/hc-naming/references/antonyms.md
@@ -1,0 +1,12 @@
+# Contrasting terms
+
+For variable/member names with opposite meanings, use fixed pairs. Referenced from the naming convention itself (`SKILL.md`).
+
+| Positive | Negative | Meaning |
+| :-- | :-- | :-- |
+| add | remove | add / remove |
+| append | extract | append to list / remove from list |
+| setup | teardown | set up / tear down |
+| initialize | terminalize | initial processing / termination processing |
+| benefit | drawback | benefit / drawback |
+| pros | cons | pros / cons |

--- a/kit/skills/core/hc-naming/references/prohibited-words.md
+++ b/kit/skills/core/hc-naming/references/prohibited-words.md
@@ -1,0 +1,26 @@
+# Prohibited words and redundant compound words
+
+This lists words that must not be used in naming (as prefixes/suffixes) and the redundant compound words that contain them. Referenced from the naming convention itself (`SKILL.md`).
+
+## Prohibited words (prefixes/suffixes)
+
+The following words are prohibited as prefixes or suffixes in naming.
+
+- `info` (`information`): Adds no new meaning (`User` alone conveys "information about the user"). Also, since `information` has the same singular and plural form, the plural of `UserInfo` cannot be distinguished.
+- `data`: Same problem as `info` in that it gives the reader no explanation whatsoever.
+- `helper`: Adds no new information to responsibility/role.
+- `manager`: A well-known naming anti-pattern that easily leads to a god class.
+- `item`: Since an element of a List is already expressed as `item`, there is no need to include it in the name.
+- `list`: Name array variables with "the plural form of the word denoting the element" (an array of `User` should be `users`, not `UserList`).
+- `util` (`utils`): Adds no new information to responsibility/role.
+- `type`: Prohibited as a suffix. Use `Category` instead (`granteeCategory` / `GranteeCategory`, `eventCategory`). `type` collides with the JSDoc type annotation, so a reader cannot tell whether the name means "a JavaScript type" or "a business classification." **The only exception is a name borrowed verbatim from an external vocabulary**, where renaming would cost a translation table between the code and the standard it implements: `mimeType` is the MIME standard's own term, `contentType` is the HTTP `Content-Type` header, and a constant mirrored from an external package keeps that package's word (an external `COLUMN_TYPE` stays `columnTypeName`).
+
+## Do not use redundant compound words
+
+- A "word that adds no new meaning" is redundant. Do not use compound words containing redundant words.
+
+| Redundant compound name | Reason | Good example |
+| :-- | :-- | :-- |
+| UserInfo | `user` alone conveys "information about the user" | userDetail / userPayment |
+| SaveData | Of course data is what gets saved. Describe specifically what | saveUser / saveMessages |
+| FileUtil | It's clear it deals with files, but describe specifically what it does | FileNameCollector |

--- a/kit/skills/core/hc-naming/references/spelling.md
+++ b/kit/skills/core/hc-naming/references/spelling.md
@@ -1,0 +1,18 @@
+# Use American spelling
+
+This lists the spelling of words that have both American and British forms. Referenced from the naming convention itself (`SKILL.md`).
+
+- For words with both American and British spellings, always write them in the American form.
+
+| American | English |
+| :--: | :--: |
+| color | colour |
+| center | centre |
+| behavior | behaviour |
+| meter | metre |
+| finalize | finalise |
+| organize | organise |
+| analyze | analyse |
+| license | licence |
+| dialog | dialogue |
+| canceled | cancelled |

--- a/kit/skills/core/hc-naming/references/verbs.md
+++ b/kit/skills/core/hc-naming/references/verbs.md
@@ -1,0 +1,30 @@
+# Method name verbs (choosing among highly abstract verbs)
+
+This lists how to choose among highly abstract verbs in method names. Referenced from the naming convention itself (`SKILL.md`).
+
+Creation-related:
+
+| Verb | Usage |
+| :-- | :-- |
+| `create~` | Instantiate an instance from a class |
+| `generate~` | Generate a primitive value |
+| `build~` | Generate a temporary object |
+| `make~` | Not used |
+
+Retrieval-related:
+
+| Verb | Usage |
+| :-- | :-- |
+| `find~` | Retrieve an entity from the DB (anything wrapping `Model.findOne()`/`Model.findAll()` uses `find`, not `get`/`fetch`) |
+| `fetch~` | Access an external API to retrieve data |
+| `extract~` | Extract data from a variable/property |
+
+Update-related:
+
+| Verb | Usage |
+| :-- | :-- |
+| `save~` | Wraps processing that persists to the DB |
+| `send~` | Access an external API to update external data |
+| `set~` | Property update (rarely used since setters are prohibited) |
+
+- For other verbs, choose a word that is faithful to the method's responsibility.

--- a/kit/skills/core/hc-properties/SKILL.md
+++ b/kit/skills/core/hc-properties/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: hc-properties
+description: "Conventions for class property definitions. Covers setting properties on `this` within the constructor, immutability (no reassignment, prohibiting Map), and the policy of not using JavaScript native private."
+---
+
+# Classes: Members / Properties
+
+This summarizes conventions related to class property definitions.
+
+## Set properties on `this` within the constructor
+
+- Properties should be set on `this` within the constructor.
+- To write tests against properties, properties should be kept accessible from outside.
+
+```javascript
+// OK: set on this within the constructor
+constructor ({
+  delimiter,
+}) {
+  this.delimiter = delimiter
+}
+```
+
+## Classes are immutable / property reassignment is prohibited
+
+- Basically, all classes are implemented as immutable. Once a property is set in the constructor, it must **not be reassigned** thereafter.
+- `this.xxx = ...` within the constructor (the initial set) is permitted. ESLint also does not prohibit this.
+- What is prohibited is **property reassignment outside the constructor**. This is enforced by ESLint.
+- Being immutable means that even a property with public access scope is "protected by coding rules." Hence there is
+  no need to make it native private for encapsulation purposes (for details, see "The meaning of `#alpha` notation and
+  the treatment of native private" below).
+- **Updating a collection (Array/Set) itself is permitted. What is prohibited is a structure that references individual elements** — pulling out a single element via `array[i]` and treating it as mutable state. This subverts the prohibition on mutable objects and is not permitted. A collection's value must always be "used all at once" (scanned/transformed/aggregated over every element as a whole). When you want to change scalar state, generate a new instance via a factory method (for the policy of not deep-freezing collections, see the class design principles convention).
+
+```javascript
+// NG: reassigning a property after creation
+scalar.normalizedValue = anotherValue
+
+// OK: if a different state is needed, generate a new instance via a factory method
+const next = Scalar.create({
+  normalizedValue: anotherValue,
+})
+```
+
+### `Map` is prohibited; `WeakMap` is free to use
+
+- **`Map` is prohibited (enforced by ESLint).** Do not use it unless there is a special reason in module development. In application code, there has been no case where `Map` was used other than as an evasion.
+- `WeakMap`, on the other hand, may be used freely. Associating objects by identity is `WeakMap`'s responsibility, and enumeration is unnecessary (when you want to enumerate, hold the keys in an Array and traverse through them).
+- Making a `Map`'s key a primitive value (`number` / `string`, etc.) is a circumvention of the reassignment prohibition and the prohibition on mutable objects. An object-keyed `Map` is also unnecessary: if enumeration is not needed, `WeakMap` suffices, and even if it is, an Array of keys + `WeakMap` covers it — so there is no reason to choose `Map`.
+- If a mutable aggregate seems necessary, reconsider the design (assemble it via a higher-order function and return it, or generate a new instance via a factory method).
+
+## The meaning of `#alpha` notation and the treatment of native private
+
+- `#` notation such as `#alpha` is not a JavaScript native private designation; it means "instance-private" in member notation.
+  (Member notation follows "Notation of Class Members" in the documentation convention.)
+- **JavaScript native private fields (`#` fields / `#` methods) must never be used unless a human specifically instructs it.**
+- Therefore, even if an instruction says `#alpha`, that alone is not a reason to implement it as a `#` field. It is normally defined as `this.alpha`.
+
+### Reason
+
+- Native private cannot be read even from an inheriting subclass, which blocks extension/substitution via inheritance.
+- This codebase basically implements all classes as immutable and does not permit reassignment of properties at all (this is also prohibited by ESLint). Therefore, even with a public access scope, it is protected by coding rules, and there is no need to make it native private.
+- Rather, it is more beneficial to avoid the disadvantage where, when you want to apply a patch (such as a hotfix) that temporarily changes behavior via inheritance, a parent class's private property would block that.

--- a/kit/skills/core/hc-readme/SKILL.md
+++ b/kit/skills/core/hc-readme/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hc-readme
+description: "Write and update README files for projects. Use this skill whenever the user asks to create or update a README file."
+---
+
+# README Skill
+
+When creating or updating a README, follow the rules in the following files.
+
+- [structure.md](./references/structure.md) — Rules for the structure of language files (`README.md` / `README.ja.md`, and the language used in in-code comments).
+- [sections.md](./references/sections.md) — Rules for README section structure (Features / Contribution / Developer / Copyright, etc.).
+- [usage.md](./references/usage.md) — Rules for placement of split-out files (the `docs/<lang>/<category>/` language-to-category directory structure, keeping the `.xx.md` suffix, not bundling with the package plus linking with absolute GitHub URLs) and rules for the Usage / Features sections.
+- [api-references.md](./references/api-references.md) — Rules for writing the API reference (member selection, Notation of Class Members, splitting multiple classes into `docs/<lang>/api/` and aggregating them via `docs/<lang>/api/index...`).
+- [sample-code.md](./references/sample-code.md) — Rules for code examples (variable naming). Applied uniformly to the code examples in every chapter.

--- a/kit/skills/core/hc-readme/references/api-references.md
+++ b/kit/skills/core/hc-readme/references/api-references.md
@@ -1,0 +1,56 @@
+# API References
+
+Rules concerning how the README's API reference is written.
+
+- If an instance member is annotated with `@public`, the API section should describe only public members carrying `@public`. Instance members without `@public` (e.g., `get Ctor`) must not be listed in the API section.
+- Static members are listed in the API section even without `@public`, if they are factory methods that create an instance of the class body, since these are part of the external interface. Other static members intended for internal use are not listed.
+- Since the README is not implementation detail, descriptions of private members are omitted. Even when an explanation of internals is needed, do not mention private member names — describe them at a conceptual level.
+- For members without `@public` where it is unclear whether they are called from outside, do not decide on your own —
+  confirm with the user whether they should be listed in the API section.
+- When there are multiple classes implemented by the application (e.g., base classes meant to be extended):
+  - Split the API for each class out into `docs/en/api/<ClassName>.md` (e.g., `docs/en/api/AlphaClass.md`; per language, `docs/<xx>/api/<ClassName>.xx.md`).
+  - Do not link directly from the README to each class file; bundle them together via `docs/en/api/index.md` (per language, `docs/<xx>/api/index.xx.md`). The README body (`## API`) links to this index, and the index holds the list of links to each class file.
+  - If splitting out, place the "Notation of Class Members" table at the top of each language's `docs/<lang>/api/index...` (if not splitting out, place it at the top of the README's `## API`).
+  - The link from the README (`## API`) to the index should use an absolute GitHub URL (`README.md` → `docs/en/api/index.md`, `README.xx.md` → `docs/<xx>/api/index.xx.md`; content under `docs/` is not bundled — see `usage.md`). Links from the index to each class file are within the same `docs/<lang>/api/` directory, so relative links are fine there.
+- Class members follow the "Notation of Class Members" notation below. This table is **placed at the top** of the API reference (`## API`). Copy the template below and use it (each table row is shared across languages; only the introductory text differs per language).
+- This notation is **governed by "Notation of Class Members" in the documentation convention**. The template below is the form in which it is transcribed into a README; when the governing table changes, align this template with it.
+
+## Notation of Class Members
+
+`README.md` (English):
+
+````markdown
+## API
+
+Class members are written with the following notation.
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+````
+
+`README.ja.md` (Japanese):
+
+````markdown
+## API
+
+クラスメンバーは以下の表記に従って記述します。
+
+| notation | members |
+| :-- | :-- |
+| `#instanceProperty` | instance property |
+| `#instanceMethod()` | instance method |
+| `#get:instanceGetter` | instance getter |
+| `#set:instanceSetter` | instance setter |
+| `.staticProperty` | static property |
+| `.staticMethod()` | static method |
+| `.get:staticGetter` | static getter |
+| `.set:staticSetter` | static setter |
+````

--- a/kit/skills/core/hc-readme/references/sample-code.md
+++ b/kit/skills/core/hc-readme/references/sample-code.md
@@ -1,0 +1,8 @@
+# Sample Code
+
+Rules concerning the code examples (sample code) in a README.
+
+- Variable names in code examples should take the form `prefix + main suffix`, with emphasis on the main suffix (the trailing word).
+  - Main suffix (trailing): a word representing the kind of value the variable holds. In most cases this corresponds to the return type of a method (context-dependent; e.g., if the return value is a constructor, use `Ctor`). In the examples within this rule, the generic word `Class` is used to illustrate it.
+  - Prefix (leading): a word used to distinguish individual instances. Instead of sequential letters like `A`, `B`, use `Alpha`, `Beta`, `Gamma`, etc.
+  - Thus `AlphaClass`, `BetaClass` are correct. A form like `ClassA`, `ClassB` — placing the main suffix first and appending a sequence number at the end — violates this rule.

--- a/kit/skills/core/hc-readme/references/sections.md
+++ b/kit/skills/core/hc-readme/references/sections.md
@@ -1,0 +1,199 @@
+# README Sections
+
+Rules concerning the section structure of a README.
+
+## Scope
+
+The README should describe only the functionality and API exposed to package users. Test/development-only code (e.g., under `app/`, `playground/`) is not something users care about, so it must not be included in the README content. Other directories with a similar nature (e.g., temporary code for samples or verification) are treated the same way.
+
+## Section order
+
+Write sections in the following order, from top to bottom. `*if needed*` marks an optional section, and should be
+written at the corresponding position depending on the content.
+
+1. Title + overview (one-line description)
+2. Table of contents *if needed* (when there are many sections)
+3. Concept / Overview *if needed* (when supplementing the purpose/background)
+4. Installation
+5. Usage / Features *pick one* (when there are multiple independent features, use Features instead of Usage, and split each feature out into a separate file. See Section rules below.)
+6. API
+7. Explanation of how it works (e.g., How memoization works) *if needed* (when understanding internal behavior is useful)
+8. Contribution
+9. License
+10. Developer
+11. Copyright
+
+The sections listed here are a **basic set**, not an exhaustive one. Sections judged to be useful given the nature and purpose of the repository may be added autonomously, without waiting for instructions (inserted at the appropriate position).
+
+## Section rules
+
+For sections whose content is fixed boilerplate, copy the following templates into the README and replace `<...>`.
+
+### Installation
+
+Almost entirely fixed text. Use the template below, replacing `<node-version>` (e.g., `20.x`) and `<package-name>`. Packages are published to npmjs.com, so `npm install` is all a consumer needs — do not add registry configuration or an authentication step to this section.
+
+`README.md` (English):
+
+`````markdown
+## Installation
+
+Requires Node.js <node-version> (the version the CI builds against).
+
+```sh
+npm install @openreachtech/<package-name>
+```
+
+It is an ES module (`"type": "module"`); import it with ESM `import` syntax.
+`````
+
+`README.ja.md` (Japanese):
+
+`````markdown
+## インストール
+
+Node.js <node-version> が必要です（CI がビルド対象とするバージョン）。
+
+```sh
+npm install @openreachtech/<package-name>
+```
+
+ES モジュール（`"type": "module"`）です。ESM の `import` 構文でインポートしてください。
+`````
+
+### Features
+
+For libraries with multiple independent features, use `Features` in place of `Usage`, and list only the feature list in the README body. Split the details of each feature out into a separate file, `docs/en/features/<feature>.md` (and, for each language, `docs/<xx>/features/<feature>.xx.md`), and link to it.
+
+- Link destinations should match the README's language (`README.md` links to `docs/en/features/<feature>.md`; `README.ja.md` links to `docs/ja/features/<feature>.ja.md`).
+- Links should use absolute GitHub URLs. Split-out files live under `docs/` and are not bundled into the npm package (see `usage.md`).
+
+`README.md` (English):
+
+```markdown
+## Features
+
+### (1) <Feature Name>
+
+[Usage of <feature>](https://github.com/openreachtech/<repository>/blob/main/docs/en/features/<feature>.md)
+
+### (2) <Feature Name>
+
+[Usage of <feature>](https://github.com/openreachtech/<repository>/blob/main/docs/en/features/<feature>.md)
+```
+
+`README.ja.md` (Japanese):
+
+```markdown
+## 機能一覧
+
+### (1) <機能名>
+
+[<機能> の使い方](https://github.com/openreachtech/<repository>/blob/main/docs/ja/features/<feature>.ja.md)
+
+### (2) <機能名>
+
+[<機能> の使い方](https://github.com/openreachtech/<repository>/blob/main/docs/ja/features/<feature>.ja.md)
+```
+
+### Contribution
+
+`README.md` (English):
+
+````markdown
+## Contribution
+
+Bug reports, feature requests, and code contributions are welcome.
+
+Feel free to contact us through GitHub Issues.
+
+```sh
+git clone https://github.com/openreachtech/<repository>.git
+cd <repository>
+npm install
+npm run lint
+npm test
+```
+````
+
+`README.ja.md` (Japanese):
+
+````markdown
+## コントリビューション
+
+バグ報告・機能要望・コード貢献を歓迎します。
+
+GitHub Issues からお気軽にご連絡ください。
+
+```sh
+git clone https://github.com/openreachtech/<repository>.git
+cd <repository>
+npm install
+npm run lint
+npm test
+```
+````
+
+### License
+
+Write according to `license` in `package.json`.
+
+- `UNLICENSED`: the body is the single word `UNLICENSED`.
+- `Apache-2.0`: use the template below.
+- `MIT`: use the template below (the current README's format).
+
+`README.md` (Apache-2.0):
+
+```markdown
+## License
+
+This project is released under the Apache License 2.0.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+```
+
+`README.ja.md` (Apache-2.0):
+
+```markdown
+## ライセンス
+
+本プロジェクトは Apache License 2.0 で公開されています。
+
+詳細は [LICENSE ファイル](./LICENSE) を参照してください。
+```
+
+`README.md` (MIT):
+
+```markdown
+## License
+
+This project is released under the MIT License.
+
+For more details, please see [in the LICENSE file](./LICENSE).
+```
+
+`README.ja.md` (MIT):
+
+```markdown
+## ライセンス
+
+本プロジェクトは MIT ライセンスで公開されています。
+
+詳細は [LICENSE ファイル](./LICENSE) を参照してください。
+```
+
+### Developer
+
+Placed before Copyright. The content is the same across languages (heading is `## Developer` in English / `## 開発者` in Japanese).
+
+```markdown
+[Open Reach Tech Inc.](https://openreach.tech)
+```
+
+### Copyright
+
+An independent section. The content is the same across languages (heading is `## Copyright` in English / `## 著作権` in Japanese; `<README作成年>` is the year the README was created). Do not guess the year — check the current year with something like `date +%Y` and fill it in.
+
+```markdown
+© <README作成年> Open Reach Tech Inc.
+```

--- a/kit/skills/core/hc-readme/references/structure.md
+++ b/kit/skills/core/hc-readme/references/structure.md
@@ -1,0 +1,10 @@
+# Structure
+
+Rules concerning the structure of a README's language files.
+
+- Create two README files: `README.md` (English) and `README.ja.md` (Japanese).
+- Comments in the code examples of `README.xx.md` should be written in the natural language indicated by `xx` (e.g., `README.ja.md` uses Japanese). `README.md`, which has no `xx`, uses the default language (English).
+- After creating or updating `README.md` and `README.xx.md`, verify consistency across all READMEs. Items to check:
+  - Structure of sample code (code lines match across languages, with differences only in comment language).
+  - Order of sections.
+  - Ordering of wording/items (order of headings, bullet points, table rows, etc.).

--- a/kit/skills/core/hc-readme/references/usage.md
+++ b/kit/skills/core/hc-readme/references/usage.md
@@ -1,0 +1,21 @@
+# Usage Section
+
+Rules concerning the README's Usage section, and the placement of files split out from the README.
+
+## Placement of split-out files (common to all splits)
+
+Files split out from the README (Usage / Features / API, etc.) all go under `docs/`. Since split-out files are not
+bundled into the npm package, they need not live in a `readme/` directory next to the README; they are unified under
+`docs/`, the standard place for documentation.
+
+- **Separate by language directory**: the default language (English) goes under `docs/en/`, other languages under `docs/<xx>/` (`xx` is the language code; currently only `docs/ja/` exists). This keeps a given language's documentation together in one folder, making it easy to copy or move per language.
+- **Place categories directly under the language directory**: `docs/<lang>/<category>/` (e.g., `docs/en/usage/`, `docs/en/features/`, `docs/en/api/`).
+- **Keep the existing language suffix at the end of the filename**: the default language uses `.md`, and language `xx` uses `.xx.md`. So English is `docs/en/usage/usage.md` and Japanese is `docs/ja/usage/usage.ja.md`.
+- **Do not bundle into the npm package** (`files` in `package.json` should only include executable code such as `lib/`, and must not include `"docs/"`). Documentation is meant to be read on GitHub / npmjs.
+- **Links from the README body to split-out files should use absolute GitHub URLs, not relative paths** (e.g., `https://github.com/openreachtech/<repository>/blob/main/docs/en/usage/usage.md`). Relative links break inside an installed package that doesn't bundle them, whereas absolute URLs work from GitHub, npmjs, and `node_modules` alike. The link destination should match the README's language (`README.md` → `docs/en/<category>/...`, `README.xx.md` → `docs/<xx>/<category>/...`).
+
+## Splitting Usage
+
+- Once Usage grows past a certain length, split it out into `docs/en/usage/usage.md` (and, per language, `docs/<xx>/usage/usage.xx.md`), and turn the README body into a link reference.
+- When there are multiple independent features, use a Features section instead of a single Usage, splitting each feature out into `docs/en/features/<feature>.md` (and, per language, `docs/<xx>/features/<feature>.xx.md`) and linking to it (see Features in `sections.md`).
+- For splitting the API, see `api-references.md` (multiple classes are split into `docs/<lang>/api/<ClassName>...` and bundled together via `docs/<lang>/api/index...`).

--- a/kit/skills/core/hc-requirement-definition/SKILL.md
+++ b/kit/skills/core/hc-requirement-definition/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: hc-requirement-definition
+description: >
+  Turn a rough, incomplete request into a requirement definition document through conversation
+  with the requester — identified requirements, observable acceptance criteria, an out-of-scope
+  list, and the points still undecided. Use this skill whenever the user brings a feature request,
+  ticket or rough idea and asks to define or write up the requirements, and before implementing
+  anything whose scope is not already written down.
+---
+
+# Requirement Definition
+
+A skill for converting a rough specification into a **requirement definition document**
+through conversation with the requester.
+
+The output is not prose that describes an idea. It is a document that a later phase can
+**verify against**: every requirement carries a stable id and at least one acceptance
+criterion, so that implementation progress, code review and test results can each point back
+to the exact requirement they satisfy.
+
+## Core principle: the document records decisions, it never records guesses
+
+A rough specification is rough because the requester has not yet decided everything. The value
+of this skill is in **surfacing what has not been decided**, not in producing a complete-looking
+document.
+
+- Anything the requester actually stated → a requirement.
+- Anything the requester did not state, and that changes the work → **ask**.
+- Anything asked but not yet answered → an **open question** in the document, never a guessed
+  answer written as if it were decided.
+- A document that looks finished but silently contains the author's assumptions is worse than
+  an obviously unfinished one, because the verification phase will then confirm the assumption
+  instead of the requirement.
+
+**Filling a gap quietly is the failure this skill exists to prevent.**
+
+## The skill is not finished until the requester approves
+
+The document has two states, recorded in its header.
+
+| State | Meaning |
+| :-- | :-- |
+| `DRAFT` | Written, but not yet confirmed by the requester. Implementation must not start. |
+| `APPROVED` | The requester has read it and confirmed it. Implementation may start. |
+
+- Never mark a document `APPROVED` on the requester's behalf.
+- A document with any unanswered open question cannot be `APPROVED`. Either the question is
+  answered, or the affected requirement is moved to out-of-scope.
+
+## Procedure
+
+Work through the five phases in order. Do not skip to drafting.
+
+| # | Phase | What happens |
+| :-- | :-- | :-- |
+| 1 | Restate | Read everything given (message, ticket, existing code) and restate the request in your own words in 3–5 lines. Get it corrected before going further. |
+| 2 | Probe | Ask the questions that change the shape of the work. See [interview.md](./references/interview.md). |
+| 3 | Decide | For each answered point, write the decision down. For each unanswered point, write an open question. |
+| 4 | Draft | Produce the document from the template. See [document-template.md](./references/document-template.md). |
+| 5 | Approve | Present the document, ask for confirmation, then set the state to `APPROVED`. |
+
+- Phases 2 and 3 repeat. One round of questions is almost never enough; two or three rounds
+  is normal.
+- Phase 1 is not optional. A restatement that gets corrected early saves the whole document
+  from being written against the wrong problem.
+
+## Rules for the conversation
+
+- **Group questions by topic and ask a round at a time.** Roughly five questions per round is
+  the upper bound. A list of twenty questions gets one answer.
+- **Order questions by how much the answer changes the work.** Ask what splits the design first
+  (does this write to storage at all? is it synchronous?), and ask details last (label text,
+  ordering).
+- **Never ask what the code already answers.** Read the repository first. Asking a requester
+  something discoverable from the existing implementation wastes the round.
+- **Offer a recommendation with each question.** Present the realistic options and say which one
+  you would pick and why. An open-ended question returns a vague answer.
+- **Ask about what must not happen**, not only about what must happen. Prohibitions are
+  requirements and are the ones most often left unstated.
+- **Do not negotiate the scope down.** If the request is larger than expected, record it fully
+  and let the requester decide what to cut. Cutting scope silently is the same failure as
+  guessing.
+
+## Requirement ids
+
+- Ids are `REQ-01`, `REQ-02`, … zero-padded to two digits, unique within one document.
+- Ids are **assigned in the order requirements are written and never renumbered.** Progress
+  entries, review findings and test names refer to these ids; renumbering invalidates all of
+  them.
+- A withdrawn requirement keeps its id with the status `WITHDRAWN` and a one-line reason. **Its
+  id is never reused** for a different requirement.
+- A requirement added after approval takes the next unused number, even if it belongs at the top
+  of the document logically. Order in the document is only for presentation; the id is the
+  identity.
+
+## Every requirement must be verifiable
+
+- Each requirement carries at least one acceptance criterion, numbered `REQ-nn-AC1`,
+  `REQ-nn-AC2`, ….
+- An acceptance criterion states an **observable outcome** — something a test, a screen or a
+  stored record can be checked against. If nobody can tell from the outside whether it holds,
+  it is not a criterion.
+- A requirement whose criteria cannot be written is a requirement that is still not understood.
+  Go back to phase 2 and ask, rather than writing a vague criterion.
+
+| Not a criterion | A criterion |
+| :-- | :-- |
+| "Sign-in works properly." | "Given a registered email and its correct password, the response contains an access token and the account's `lastSignInAt` is updated." |
+| "Handles errors." | "Given a password that does not match, the response is the `invalid-credentials` error and no token is issued." |
+| "Should be fast." | "A sign-in request returns within 1 second with 100 concurrent requests." |
+
+## The out-of-scope list is mandatory
+
+- Every document has an out-of-scope section, and it is never empty.
+- List what a reader would reasonably assume is included but is not, with a one-line reason
+  (deferred / not requested / handled elsewhere).
+- This section is what prevents the review phase from reporting deliberate omissions as defects.
+
+## Where the document lives
+
+```
+docs/features/<feature-slug>/
+└── requirements.md      the requirement definition document
+```
+
+- `<feature-slug>` is lower-case kebab-case naming the feature (`user-sign-in`,
+  `invoice-export`).
+- One feature, one directory. Later phases place their own documents in the same directory, so
+  that everything about one feature is found together.
+- If the project already has an established location for specifications, follow the project and
+  keep the file name `requirements.md`.
+- Write it in the language the reader is using, as the documentation convention requires of any document generated for a reader.
+
+## Amending an approved document
+
+- **Never silently rewrite an approved requirement.** Later phases have already been verified
+  against the old text, and a silent edit makes a passing review meaningless.
+- Editorial fixes (typo, clearer wording, same meaning) may be applied directly.
+- A change in meaning follows one of these two forms, and is recorded in the document's change
+  log with the date and the reason.
+
+| Change | How to record it |
+| :-- | :-- |
+| A requirement is dropped | Keep the id, set its status to `WITHDRAWN`, give the reason. |
+| A requirement changes meaning | Set the old id to `SUPERSEDED BY REQ-nn`, add the new text under a new id. |
+
+- Adding a new requirement to an approved document returns the document to `DRAFT` until the
+  requester approves the addition.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Instead |
+| :-- | :-- | :-- |
+| Writing the document before asking anything | The document becomes the author's design, and the requester reviews their own idea back to front | Restate first, probe second, draft third |
+| A plausible answer written in place of an unanswered question | The verification phase confirms the guess and reports success | Record it as an open question |
+| Requirements phrased as implementation ("add a `SignInResolver`") | Locks the design and cannot be verified as an outcome | Phrase the outcome; leave the design to the implementation phase |
+| One giant requirement covering a whole feature | Cannot be marked partially done, cannot be reviewed piece by piece | Split until each requirement has its own acceptance criteria |
+| Renumbering ids to tidy the document | Breaks every progress entry, review finding and test that refers to them | Ids are permanent; only the order of presentation may change |
+| Leaving out-of-scope empty | Every omission later looks like a defect | Always list what was deliberately excluded |
+
+## Detail files
+
+- [interview.md](./references/interview.md) — the probe checklist (what to ask per topic and
+  why it changes the work) and the rules for running a question round.
+- [document-template.md](./references/document-template.md) — the document template and the
+  rules for each field.

--- a/kit/skills/core/hc-requirement-definition/references/document-template.md
+++ b/kit/skills/core/hc-requirement-definition/references/document-template.md
@@ -1,0 +1,235 @@
+# Document Template
+
+The template for `docs/features/<feature-slug>/requirements.md`, and the rules for each field.
+
+## Template
+
+````markdown
+# <Feature name>
+
+| Field | Value |
+| :-- | :-- |
+| State | DRAFT |
+| Feature slug | `<feature-slug>` |
+| Requester | <who asked for this> |
+| Last updated | YYYY-MM-DD |
+
+## Background
+
+<2–5 lines: the problem being solved and who has it. What happens today without this feature.>
+
+## Scope
+
+<3–6 lines: what this feature does, in the requester's vocabulary. No implementation terms.>
+
+## Out of scope
+
+| Not included | Reason |
+| :-- | :-- |
+| <thing a reader would assume is included> | <deferred / not requested / handled elsewhere> |
+
+## Requirements
+
+### REQ-01 — <short title>
+
+<One or two sentences stating the required outcome.>
+
+- **REQ-01-AC1** — Given <state>, when <action>, then <observable outcome>.
+- **REQ-01-AC2** — Given <state>, when <action>, then <observable outcome>.
+
+### REQ-02 — <short title>
+
+...
+
+## Non-functional requirements
+
+### REQ-nn — <short title>
+
+<Volume, response time, retention, compatibility. Written the same way, with measurable criteria.>
+
+- **REQ-nn-AC1** — <measurable outcome>.
+
+## Assumptions
+
+| # | Assumption | Why it was decided this way |
+| :-- | :-- | :-- |
+| A-1 | <a decision made on the requester's behalf> | <reason, and that it was deferred to us> |
+
+## Open questions
+
+| # | Question | Blocks | Status |
+| :-- | :-- | :-- | :-- |
+| Q-1 | <the unresolved point> | REQ-nn | OPEN |
+
+## Change log
+
+| Date | Change | Reason |
+| :-- | :-- | :-- |
+| YYYY-MM-DD | Initial draft | — |
+````
+
+## Field rules
+
+### State
+
+- `DRAFT` until the requester confirms; `APPROVED` afterwards.
+- Any `OPEN` row in the open questions table forces `DRAFT`.
+- Adding a requirement to an approved document returns it to `DRAFT`.
+
+### Out of scope
+
+- Never empty. If nothing was excluded, the scope was not probed.
+- Each row names something a reader would otherwise assume is included.
+
+### Requirements
+
+- Heading form: `### REQ-nn — <short title>`. The title is a noun phrase naming the outcome, not
+  a task.
+- Ids are assigned in writing order, never renumbered, never reused.
+- The body states the outcome. It must not name a class, a file or a library — the design is
+  decided by the implementation phase, not here.
+- Requirements that no longer apply keep their heading and gain a status line directly under it.
+
+```markdown
+### REQ-03 — Suspended accounts are refused
+
+**Status: WITHDRAWN** — the suspension feature was canceled (2026-08-02).
+```
+
+```markdown
+### REQ-04 — Sign-in token lifetime
+
+**Status: SUPERSEDED BY REQ-11** — the lifetime became role-dependent (2026-08-02).
+```
+
+### Acceptance criteria
+
+- At least one per requirement. Numbered `REQ-nn-AC1` upward within the requirement, never
+  renumbered.
+- Each states the state before, the action, and the outcome that is observable from outside.
+- Cover the failure paths, not only the success path. A requirement with only a happy-path
+  criterion is under-specified.
+- Do not state the implementation ("the resolver calls the validator"). State what a check can
+  see (the response, the stored record, the screen).
+
+### Non-functional requirements
+
+- Use the same id sequence as the functional requirements — the sequence is document-wide, so
+  that no two requirements ever share an id.
+- Only include one when it has a measurable criterion. "Fast" is not a requirement; "returns
+  within 1 second at 100 concurrent requests" is.
+
+### Assumptions
+
+- Only for decisions the requester explicitly deferred. A decision the requester never saw is an
+  open question, not an assumption.
+- Each row says why the decision went the way it did, so it can be revisited.
+
+### Open questions
+
+- `Blocks` names what cannot be settled until the question is answered. That is one of two
+  things, and never blank:
+
+| The question is about | What `Blocks` names |
+| :-- | :-- |
+| A requirement that already has an id | The requirement ids — `REQ-02`, or `REQ-02, REQ-05` |
+| Whether something should become a requirement at all | `a new requirement: <what it would cover>` |
+
+- A question that blocks neither is a note, not an open question, and it does not belong in the
+  document.
+- A question of the second kind is the one most often dropped, because there is no id to point
+  at yet. Dropping it is how unrequested work gets built: nobody decided it, so nothing recorded
+  the decision, and the review phase later reports the code as unrequested.
+- Status is `OPEN` or `ANSWERED: <the answer>`. Answered rows stay in the table as a record. When
+  a question of the second kind is answered yes, the new requirement is added and the row
+  becomes `ANSWERED: added as REQ-nn`.
+
+### Change log
+
+- One row per meaning-changing edit, with the date and the reason.
+- Editorial edits are not logged.
+
+## Worked example
+
+````markdown
+# Account Sign-in
+
+| Field | Value |
+| :-- | :-- |
+| State | APPROVED |
+| Feature slug | `account-sign-in` |
+| Requester | Product team |
+| Last updated | 2026-08-02 |
+
+## Background
+
+Accounts can be registered but there is no way to sign in, so every screen behind
+authentication is unreachable. Support currently issues tokens by hand.
+
+## Scope
+
+An account holder signs in with the email address and password used at registration and
+receives an access token that identifies them on subsequent requests. Failed attempts are
+limited so that a password cannot be guessed by repetition.
+
+## Out of scope
+
+| Not included | Reason |
+| :-- | :-- |
+| Password reset | Deferred to the next release |
+| Social sign-in | Not requested |
+| Multi-factor authentication | Handled by a separate feature already in design |
+
+## Requirements
+
+### REQ-01 — Sign-in with email and password
+
+An account holder supplies an email address and a password and, when they match a registered
+account, receives an access token.
+
+- **REQ-01-AC1** — Given a registered account, when its email and correct password are
+  supplied, then an access token is returned and the account's last-sign-in time is updated to
+  the time of the request.
+- **REQ-01-AC2** — Given a registered account, when the password does not match, then the
+  `invalid-credentials` error is returned and no token is issued.
+- **REQ-01-AC3** — Given an email address that is not registered, when sign-in is attempted,
+  then the `invalid-credentials` error is returned — the same error as a wrong password, so
+  that registered addresses cannot be discovered.
+
+### REQ-02 — Failed attempts are limited
+
+Repeated failures for the same email address are refused for a period.
+
+- **REQ-02-AC1** — Given five consecutive failures for one email address within 15 minutes,
+  when a sixth attempt is made, then the `too-many-attempts` error is returned even if the
+  password is correct.
+- **REQ-02-AC2** — Given the lock is in effect, when 15 minutes have passed since the fifth
+  failure, then a correct password succeeds again.
+- **REQ-02-AC3** — Given a successful sign-in, then the failure count for that email address is
+  cleared.
+
+## Non-functional requirements
+
+### REQ-03 — Sign-in response time
+
+- **REQ-03-AC1** — A sign-in request returns within 1 second at 100 concurrent requests.
+
+## Assumptions
+
+| # | Assumption | Why it was decided this way |
+| :-- | :-- | :-- |
+| A-1 | The failure count is kept per email address, not per source address | The requester deferred the choice; per-address is what protects the account itself |
+
+## Open questions
+
+| # | Question | Blocks | Status |
+| :-- | :-- | :-- | :-- |
+| Q-1 | Should an administrator be able to clear a lock manually? | REQ-02 | ANSWERED: no, out of scope for this release |
+
+## Change log
+
+| Date | Change | Reason |
+| :-- | :-- | :-- |
+| 2026-08-02 | Initial draft | — |
+| 2026-08-02 | Added REQ-01-AC3 | The requester confirmed unknown addresses must not be distinguishable |
+````

--- a/kit/skills/core/hc-requirement-definition/references/interview.md
+++ b/kit/skills/core/hc-requirement-definition/references/interview.md
@@ -1,0 +1,117 @@
+# Interview
+
+The rules for running the question rounds, and the checklist of what to probe.
+
+## Running a question round
+
+1. **Read the repository before the round.** Existing models, resolvers, screens and constants
+   answer many questions for free. Bring what you found into the question: "the account table
+   already stores a `status` column with `active` / `suspended` — should a suspended account be
+   rejected here?"
+2. **Pick the questions whose answers change the shape of the work.** A question whose two
+   possible answers lead to the same implementation is not worth a round.
+3. **Attach the options and a recommendation.** State the realistic choices, name the one you
+   would take, and say what it costs. The requester answers a concrete choice far faster than an
+   open question.
+4. **Say what happens if it is left unanswered.** "If we don't decide this, I will record it as
+   an open question and the feature cannot be approved" makes the cost of silence visible.
+5. **Write down every answer immediately**, in the requester's terms. An answer that lives only
+   in the conversation is lost by the next round.
+
+## What not to ask
+
+- Anything discoverable from the code, the schema, the existing screens or the project
+  conventions.
+- Implementation choices that are the implementer's to make (which class, which directory, which
+  helper). Ask about outcomes and constraints, not about structure.
+- Questions whose answer you would not act on differently either way.
+
+## Probe checklist
+
+Walk the topics in this order. Each row states what the answer changes — skip a row only when
+the answer is already fixed by the request or by the existing system.
+
+### Purpose and boundary
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| What problem does this solve, for whom? | Whether the requested solution is the right one at all |
+| What happens today without it? | Whether there is an existing path to extend rather than a new one to build |
+| What is deliberately not included? | The out-of-scope list, which decides what the review phase must not report |
+| Is this replacing something? What happens to the old path? | Whether a migration and a removal are part of the work |
+
+### Actors and triggers
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| Who performs this — which role, signed in or not? | Authorization requirements and the endpoint it belongs to |
+| What starts it — a user action, a schedule, an external event, another feature? | Whether this is a request-time path or a background path |
+| Can it happen concurrently for the same target? | Whether uniqueness, locking or idempotency requirements are needed |
+| How often, and at what volume? | Non-functional requirements, and whether the naive approach is acceptable |
+
+### Input
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| What exactly is supplied, and which parts are optional? | The input contract and its validation requirements |
+| What is rejected, and what does the requester expect to happen then? | Error requirements, which are the most commonly omitted ones |
+| Where does each value come from — typed by a person, chosen from a list, sent by a system? | How strictly it must be validated and whether it can be trusted |
+
+### Behaviour and output
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| What does the actor see or receive when it succeeds? | The observable outcome the acceptance criteria are written from |
+| What must be recorded, and must the previous value be kept? | Whether history / audit requirements exist |
+| What else must happen as a consequence — notification, external call, downstream update? | Side-effect requirements, and whether they are part of the same operation |
+| If a consequence fails, must the whole thing fail? | Whether the side effect is inside or outside the transaction boundary |
+
+### Failure and edge cases
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| What if the target does not exist, or was deleted meanwhile? | Requirements that would otherwise be discovered during implementation |
+| What if it is requested twice — is the second one an error, or a no-op? | Idempotency requirements |
+| What is the behavior at the boundaries — empty, one, maximum, over maximum? | Limit requirements and their acceptance criteria |
+| Which failures must the actor see, and which are internal only? | Error-exposure requirements |
+
+### Constraints
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| Who is allowed to see or do this, and who must be refused? | Authorization requirements, stated as their own requirements |
+| How long must the data be kept, and can it be deleted? | Retention requirements |
+| Is there a required response time or throughput? | Whether a non-functional requirement with a measurable criterion is needed |
+| Does an existing client depend on the current behavior? | Backward-compatibility requirements and whether a versioned path is required |
+
+### Verification
+
+| Probe | What the answer changes |
+| :-- | :-- |
+| How will the requester check this is done? | The acceptance criteria, in the requester's own words |
+| Which case, if it broke, would matter most? | Which criteria the test phase must cover first |
+| Is there existing data this must keep working with? | Whether the criteria must be written against real data as well as fresh data |
+
+## Turning answers into requirements
+
+- One decision, one requirement. If an answer covers two independently checkable outcomes, it
+  becomes two requirements with two ids.
+- Write the requirement in the requester's vocabulary, not in the codebase's vocabulary. The
+  requester must be able to confirm it without reading the implementation.
+- Write the acceptance criterion in the given / when / then shape — the state before, the
+  action, and the observable outcome. It does not have to use those words, but all three parts
+  must be present.
+- A prohibition ("an unverified account must never receive a token") is a requirement. Give it
+  its own id.
+
+## When the requester will not decide
+
+Some questions come back as "you decide" or stay unanswered across rounds. Handle them like
+this, never by guessing silently.
+
+| Situation | What to do |
+| :-- | :-- |
+| The requester defers a genuinely technical choice | Decide it, and record the decision in the assumptions section with the reason |
+| The requester cannot decide yet | Record it as an open question; the document stays `DRAFT` |
+| The answer only matters for a rare case | Record the rare case as out-of-scope for now, with the reason |
+| Deciding it would change the whole design | Stop. Say plainly that the work cannot be scoped without it |

--- a/kit/skills/core/hc-scope/SKILL.md
+++ b/kit/skills/core/hc-scope/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: hc-scope
+description: "Conventions for scope references among class members. Covers using `this` for references between static members, and going through `#get:Ctor` when referring from an instance to static members."
+---
+
+# Classes: Shared / Scope
+
+This summarizes conventions related to scope references among class members.
+
+## References between static members should use `this`
+
+- References between static members should use `this` rather than the class name.
+  (Using `this` ensures that even when called from an inheriting subclass, the subclass's own definition is referenced.)
+
+```javascript
+// NG
+static create ({
+  characters = RandomTextGenerator.DEFAULT_CHARACTERS,
+} = {}) {
+  return new this({ characters })
+}
+
+// OK
+static create ({
+  characters = this.DEFAULT_CHARACTERS,
+} = {}) {
+  return new this({ characters })
+}
+```
+
+## When referencing a static member from an instance member, go through `#get:Ctor`
+
+- When referencing a static member from an instance method or getter, go through `this.constructor` rather than hardcoding the class name.
+- Define the conventional getter `#get:Ctor`, which returns `this.constructor`, and reference the member in the form `this.Ctor.staticMember`.
+- Using `this.constructor` ensures that even when called from an inheriting subclass, the subclass's own static definition is referenced. Hardcoding the class name would fix it to the base class's definition.
+- In the body of `#get:Ctor`, **type resolution (a type cast) is needed** between `return` and `this.constructor`. Since the type of `this.constructor` is broad, cast it to the type of the class in question.
+
+```javascript
+/**
+ * get: Constructor of this class.
+ *
+ * @returns {typeof SampleClass} Constructor of this class.
+ */
+get Ctor () {
+  return /** @type {typeof SampleClass} */ (this.constructor)
+}
+
+someInstanceMethod () {
+  return this.Ctor.someStaticMethod()
+}
+```
+
+### When a derived class has more static members to reference, override `#get:Ctor`
+
+- When a derived class gains additional "static members referenced from instance members," override and redefine `#get:Ctor` in the derived class, resolving the type to the derived class's type.
+
+```javascript
+class DerivedSample extends BaseSample {
+  /** @override */
+  get Ctor () {
+    return /** @type {typeof DerivedSample} */ (this.constructor)
+  }
+
+  someDerivedMethod () {
+    return this.Ctor.derivedStaticMethod()
+  }
+}
+```
+
+### Do not define a `#get:xxxx` shortcut for `this.Ctor.xxxx`
+
+- Do not define a getter (`#get:xxxx`) solely to access `this.Ctor.xxxx` (a static member). Write static member access explicitly as `this.Ctor.xxxx`.
+- Reason: inserting such a getter makes it **implicit, from the caller's `this.xxxx`, that this is a static-member call**.
+
+```javascript
+// NG: a shortcut getter for this.Ctor.DEFAULT_VALUE (makes the static reference implicit)
+get defaultValue () {
+  return this.Ctor.DEFAULT_VALUE
+}
+
+// OK: reference static members explicitly via this.Ctor
+someInstanceMethod () {
+  return this.Ctor.DEFAULT_VALUE
+}
+```

--- a/kit/skills/core/hc-skill-updating/SKILL.md
+++ b/kit/skills/core/hc-skill-updating/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: hc-skill-updating
+description: "Conventions for creating new skills (SKILL.md) or updating existing ones. Defines how to name a skill (the domain prefix, and the folder name that must equal `name:`), where the folder goes among the three domain directories, and the conventions to follow when writing the body and the description."
+---
+
+# Skill Updating
+
+This gathers the conventions for creating new skills (`SKILL.md`) or updating existing ones.
+
+- When writing or updating `SKILL.md`, follow the documentation convention.
+
+## Naming a skill
+
+`name:` is the skill's official command name — what a user types as `/name` — and it is also the
+skill's own folder name and the folder name it installs as. **One string, three places.** Choose it
+for the reader who sees a flat list of skills and never sees this repository.
+
+- **The name begins with its domain's prefix**: `hc-` for a skill under `core/`, `hb-` under
+  `backend/`, `hf-` under `frontend/`. The prefix is what tells a reader of that flat list which
+  skills came from this library, and which domain each belongs to.
+- **`name:` and the folder name must be the same string.** They are not two facts to keep in sync
+  by habit: the build that produces the installable output and the repository's skill-name audit
+  both refuse to proceed on a mismatch.
+- **The name is 4–64 characters of `[a-z0-9-]`**, of which the prefix takes 3. A single case only.
+- **Uniqueness needs no thought.** One directory cannot hold two folders of one name, and the three
+  prefixes cannot overlap, so no two skills in the library can collide.
+- **Renaming is a breaking change** for repositories that already invoke the skill, so choose
+  deliberately the first time. Moving a skill to another domain is a rename too — the prefix
+  changes with it.
+
+After the prefix, name the subject, not the source tree:
+
+- **Leave out words that only place the skill within its domain.** A backend skill does not repeat
+  the framework it is for, and a `core` skill does not carry a classifying word like
+  `declarations`, `shared` or `members` — `hc-async`, `hc-accessors`, `hb-agent-loop`.
+- **Keep a classifying word when it is what a reader would search for**: `hc-classes-constructor`,
+  `hc-modules-exports`, `hf-css-units`.
+- **Prefer a short marker over a spelled-out grouping word**: `hf-cp-table` for a component,
+  `hf-css-props-naming` for CSS custom properties.
+- **One word after the prefix is enough when it names the concept unambiguously** (`hc-async`,
+  `hc-jest`). Qualify it when sibling skills have an equal claim to the same word: CSS prohibitions
+  are `hf-css-prohibits` and `hf-css-props-prohibits`, not two skills both called prohibits.
+
+## Writing and updating the description
+
+- `description:` should indicate the skill's scope (which domain, and what it defines), not name an individual rule.
+- When a skill is updated (rules added or removed), update `description:` to reflect what was added or removed. Do not let `description:` go stale by changing only the body.
+
+### Keep the description under 500 characters
+
+- **Every description is loaded into every conversation**, whether the skill is used or not, because the agent needs them to route. The cost is paid up front by all users of the library, so a description is not free space.
+- **Never summarize the procedure in the description.** A description complete enough to act on gets acted on *instead of* the skill: it is already in context, and opening `SKILL.md` is an extra step the agent can skip. A skill that says "run three passes" in its body but "reviews correctness and conventions" in its description will get one pass.
+- Do not enumerate the body's sections, steps, checks, or file layout. That is a table of contents, and it belongs in the body.
+- Write only what decides routing: **scope** (domain, and what kind of artifact), **triggers** (the words and situations that should reach this skill), and the **boundary** (what this skill is not, and which convention owns that instead). What discriminates between sibling skills is the boundary, never the list of internal checks — siblings share those.
+- 500 characters is the ceiling, not the target. Most skills route correctly in 250–400. Length is a proxy: if the description is long, it is almost always because it started summarizing the procedure.
+- Refer to a neighbouring convention descriptively ("input validation belongs to the resolver input-validator convention"), never by path.
+- Quote the value (`description: "..."`) or use a block scalar (`description: |-`). A bare scalar containing `: ` is not valid YAML and the frontmatter will fail to parse.
+
+## Directory structure
+
+- A single skill is one directory containing `SKILL.md`.
+- Supplementary reference documents go under `references/` within that skill's directory, and any
+  executable helpers under `scripts/`.
+- A skill directory holds no `SKILL.md` below its own top level. Its subdirectories are its own
+  files, never more skills.
+- There are exactly three domain directories, and a skill folder sits **directly** inside one of
+  them — one level, with no grouping directories in between:
+
+```
+lib/skills/
+├── core/      hc-*   Common/foundational (conventions applied across backend/frontend)
+├── backend/   hb-*   Backend-specific
+└── frontend/  hf-*   Frontend-specific
+```
+
+So every skill in the library is at `lib/skills/<domain>/<name>/SKILL.md`, and nowhere else. There
+is no `backend/<framework>/`, no `frontend/<library>/components/`: what a nested directory would
+have said belongs in the name instead, where the reader of an installed skill can see it.
+
+## Placement of skills
+
+- Common conventions that do not depend on a specific domain go under `core/`.
+- Conventions specific to a particular domain go under that domain's directory.
+- The prefix must match the directory. Deciding the domain and deciding the first three characters
+  of the name are the same decision.
+
+## Keep skills self-contained
+
+- Write a skill so that it is meaningfully complete on its own. **Information that is not self-contained within the skill must not be put into `SKILL.md`.**
+- Specifically, do not cite links to external websites (URLs to internal documents, tickets, articles, etc.) in `SKILL.md` as the basis or reference for a convention. If the reader cannot access the link destination, the meaning of the convention is lost.
+- Information that exists only at the link destination (tables, concrete examples, rationale, etc.) should not be replaced by a link; instead, transcribe the necessary content into `SKILL.md` (or into `references/` within the same skill) so it is self-contained.
+- Cross-skill relative path references are prohibited. A link that traverses to another skill via `../` describes this repository's source tree, which the consuming repository does not have: installed skills are siblings under `.claude/skills/`, so the path is wrong the moment it ships.
+- Referring to another skill **by its name** is fine, and is the clearer choice when the reader has to go there ("see `hc-jsdoc`"). The name is stable — it changes only by a deliberate rename, which is a breaking change decided on purpose, never as a side effect of reorganizing the source. Where the reader only needs to know that a convention exists elsewhere, name the concept instead ("see the documentation convention").
+- Relative references to files within the same skill folder (e.g., `./references/structure.md`) are permitted, since they move together with the skill and their relative relationship is preserved.

--- a/kit/skills/core/hc-statements/SKILL.md
+++ b/kit/skills/core/hc-statements/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: hc-statements
+description: "Conventions for statements and control flow. Covers prohibiting the literal `undefined` in production code, avoiding sequential processing in favor of higher-order functions, and policies on ternary expressions and if statements."
+---
+
+# Shared: Statements
+
+Summarizes conventions for statements and control flow. Applied across both functions and methods.
+
+## Do not write the literal text `undefined` in production code
+
+- Do not write the literal text `undefined` (as a literal or identifier) in real code files (production code).
+- Reason: `undefined` is not a "value." If `undefined` is used intentionally as a value, it becomes impossible to distinguish between "a bug" and "intentional logic."
+- When you intentionally want to express "no value," use `null` instead of `undefined`. Since `null` does not arise naturally in context, it can be used as an intentional value.
+- Do not write `undefined` in JSDoc either. When a type annotation needs to express "no value," use `null` instead of `undefined` (e.g. `@returns {string | null}`).
+- This convention is enforced by ESLint's `no-undefined` rule. However, in `eslint.config.js`, `no-undefined: 'off'` is set for `tests/**/*.js`, so writing `undefined` in test files is exempt from this prohibition.
+
+### Cannot distinguish between a bug and an intentional value
+
+Using `undefined` as an intentional value makes it impossible to distinguish between "a bug" and "intentional logic" in cases like the following.
+
+```javascript
+const object = {
+  alpha: undefined, // NG: undefined is written as an intentional value
+}
+
+console.log(object.alpha) // undefined
+console.log(object.beta) // undefined
+
+console.log('alpha' in object) // true 🔥 (the key ends up existing)
+console.log('beta' in object) // false
+
+// ---------------
+
+function extractAlpha (object) {
+  object.alpha // <-- ❌️ Forgot to write return (a bug)
+}
+
+console.log(
+  extractAlpha({})
+) // undefined (a bug, but indistinguishable from a normal return value)
+```
+
+### Use `null` instead of `undefined`
+
+Since `null` does not arise naturally depending on context, it can be used as an intentional value.
+
+```javascript
+// NG: writing undefined
+function extractAlpha (object) {
+  return object.alpha
+}
+
+// OK: resolve to null with ?? null (expresses an intentional "no value")
+function extractAlpha (object) {
+  return object.alpha
+    ?? null
+}
+
+console.log(
+  extractAlpha({})
+) // null
+```
+
+## Sequential processing is prohibited; write with higher-order functions
+
+- Sequential processing (imperative loops) using `for` and the like is prohibited.
+- Express iteration/transformation with higher-order functions (`map` / `filter` / `reduce` / `Array.from`, etc.).
+
+Example:
+
+```javascript
+// NG: sequential processing
+let result = ''
+for (let i = 0; i < length; i++) {
+  result += pick()
+}
+
+// OK: higher-order function
+const result = Array.from({ length }, () => pick())
+  .join('')
+```
+
+- **Achieving sequential processing via recursion in a method or function in order to evade this prohibition is also prohibited.** Replacing a loop with recursion is still sequential processing, and amounts to a workaround. Express iteration with higher-order functions.
+
+```javascript
+// NG: achieving sequential processing via recursion (a workaround)
+function build ({ length, result = '' }) {
+  if (length === 0) {
+    return result
+  }
+
+  return build({
+    length: length - 1,
+    result: `${result}${pick()}`,
+  })
+}
+
+// OK: higher-order function
+const result = Array.from({ length }, () => pick())
+  .join('')
+```
+
+## Do not discard the return value of a higher-order function (except `Array#forEach()`)
+
+- Do not discard the return value of a higher-order function (`map` / `filter` / `reduce`, etc.). If the return value is neither assigned to a variable nor used as a return value, that code is prohibited.
+- If the sole purpose is a side effect on each element (such as logging), use `Array#forEach()`. `forEach` is a higher-order function that assumes an `undefined` return value, so it is exempt from this rule.
+- In particular, using `reduce` solely for side effects, returning the accumulator unchanged and discarding the return value, is a hack to evade the prohibition on sequential processing, and is prohibited.
+
+```javascript
+// NG: using reduce solely for side effects and discarding the return value (a workaround to evade the sequential-processing prohibition)
+array.reduce(
+  (_, it) => {
+    this.logger.log('value:', it)
+
+    return _
+  },
+  null
+)
+
+// OK: express a side effect on each element with forEach
+array.forEach(it => {
+  this.logger.log(
+    'value:',
+    it
+  )
+})
+```
+
+### The usage of `Array#forEach()` is limited
+
+- ESLint prohibits writing an assignment statement inside `Array#forEach()`.
+- Also, `if` statements are prohibited inside higher-order functions (express branching with `filter` or a conditional expression).
+- Therefore, what can be written with `forEach` is limited to **a pure side effect that involves no assignment or branching** (such as logging or calling an external API).
+- **An implementation that processes all elements equally while building up a result by pushing elements into an array or `Map` defined with `let`/`const` in the outer scope violates the spirit of the sequential-processing prohibition and is not allowed.** `push()` / `set()` are not assignment statements, so they slip past ESLint, but in substance this is an imperative loop and amounts to a workaround. Express iteration that assembles a result with `map` / `filter` / `reduce` / `Array.from`, etc., and receive it as a return value.
+
+```javascript
+// NG: assembling a result by pushing into an outer array inside forEach (violates the spirit of the sequential-processing prohibition)
+const results = []
+array.forEach(it => {
+  results.push(transform(it))
+})
+
+// NG: assembling by setting into an outer Map
+const map = new Map()
+array.forEach(it => {
+  map.set(it.id, transform(it))
+})
+
+// OK: assemble with map and receive the return value
+const results = array
+  .map(it => transform(it))
+```
+
+## The callback passed to a higher-order function should basically be a single statement
+
+- The body of a function (callback) passed as an argument to a higher-order function should ideally consist of **only a single statement**.
+- Even when writing multiple statements, limit it to what can be expressed as a single method name (i.e., extracted as
+  a single responsibility).
+- When there are multiple responsibilities, make full use of `Array#filter()` / `Array#map()` to split each stage into a single responsibility.
+
+```javascript
+// NG: the callback mixes multiple responsibilities (filtering + transformation)
+const names = users.map(it => {
+  if (!it.enabled) {
+    return null
+  }
+
+  return it.name.toUpperCase()
+})
+
+// OK: split into filtering with filter and transformation with map, making each stage a single responsibility
+const names = users
+  .filter(it => it.enabled)
+  .map(it => it.name.toUpperCase())
+```
+
+## Do not casually extract the body of map() into a method
+
+- Do not casually extract the body of the higher-order function passed to `Array#map()` into a method.
+- If the reason is "I want to use an `if` statement but can't inside a higher-order function," first consider using `.filter().map()`.
+
+```javascript
+// NG: extracting the body of map into a method just to use if
+items.map(it =>
+  this.convertItem({ item: it }) // convertItem merely branches internally with if
+)
+
+// OK: separate the condition with filter, then map
+items
+  .filter(it => it.enabled)
+  .map(it => it.value)
+```
+
+## Conditional (ternary) expressions
+
+### Basic policy
+
+- The purpose of using a conditional expression is, in principle, limited to "branching between values of the same kind based on a condition." This is a means for using `const` instead of `let`.
+- There are two cases for switching a value based on a condition:
+  1. When assigning to a variable with `const`
+  2. When passing a conditional expression to a `return` statement
+
+### Prohibition rules
+
+**(1) Prohibited when it embodies the meaning of a control statement**
+
+```javascript
+// NG: embodies the meaning of a control statement
+return this.nextComposer
+  ? Object.setPrototypeOf(
+    this.integratedResolver,
+    this.nextComposer.composeResolver()
+  )
+  : this.integratedResolver
+
+// OK: control it with an early return
+if (!this.nextComposer) {
+  return this.integratedResolver
+}
+
+return Object.setPrototypeOf(
+  this.integratedResolver,
+  this.nextComposer.composeResolver()
+)
+```
+
+**(2) Prohibited when the branched values are not of the same kind**
+
+```javascript
+// NG: branching to a default value (not the same kind)
+return condition
+  ? processValue()
+  : defaultValue
+
+// OK
+if (!condition) {
+  return defaultValue
+}
+
+return processValue()
+```
+
+```javascript
+// NG: branching to objects of different shapes (not the same kind)
+return condition
+  ? {
+    alpha: 100,
+  }
+  : {} // has no alpha property
+
+// OK
+if (!condition) {
+  return {}
+}
+
+return {
+  alpha: 100,
+}
+```
+
+OK when the values are of the same kind:
+
+```javascript
+// OK
+const STATUS = {
+  OK: 0,
+  ERROR: 1,
+}
+
+return condition
+  ? STATUS.OK
+  : STATUS.ERROR
+
+// OK
+return condition
+  ? 100
+  : 200
+```
+
+When you want to assign to `const` but the values are not of the same kind, extract it into a method and refactor with an early return:
+
+```javascript
+// NG
+const value = this.condition
+  ? this.processValue()
+  : this.defaultValue
+
+// OK
+const value = this.generateValue()
+
+// ...
+
+generateValue () {
+  if (!this.condition) {
+    return this.defaultValue
+  }
+
+  return this.processValue()
+}
+```
+
+## Treat all elements of an array equally in higher-order functions
+
+- When handling an array with a higher-order function such as `map` / `filter` / `forEach`, do not special-case a particular element (such as the first one) by checking `index`. Transform/process all elements equally with the same logic.
+- Even when it looks like you want to change the result only for the first element, first consider whether "processing all elements equally and absorbing the difference in a batch step such as after joining" is possible (see "Do not casually add if statements" in this skill for a concrete example).
+- Exception: when `reduce()` / `reduceRight()` omits the second argument (the initial value `initialValue`), **the first element of the array is used as the initial value of the accumulator**. In this case, since **the second element onward is folded equally**, excluding the first element which is assigned to the accumulator, this does not violate the principle.
+
+```javascript
+// OK: omitting initialValue -> first element becomes the accumulator, second element onward is folded equally
+const total = numbers
+  .reduce((total, it) => total + it)
+```
+
+## Do not access array elements by subscript (`[]`)
+
+- Accessing an individual array element via the `[]` operator (`array[0]` / `array[i]`) is prohibited.
+- Pulling out a specific element to handle it specially violates "Treat all elements of an array equally in higher-order functions" (above), and is a circumvention of the discipline that a collection is "always used all at once" (the class design principles convention / the property-definition convention).
+- Handle every element together with `map` / `filter` / `reduce` / `for...of`, etc., without pulling out individual elements.
+
+```javascript
+// NG: accessing an individual element by subscript
+const head = segments[0]
+
+// OK: handle every element together with map / reduce, etc.
+segments
+  .map(it => this.normalize({ segment: it }))
+```
+
+### Exception: first / last element
+
+- The **last element** may only be obtained via `Array#at(-1)` (destructuring cannot express the last element).
+- The **first (leading) element(s)** are obtained via destructuring (`const [first] = array` / `const [first, second] = array`). Do not use `array[0]` / `Array#at(0)`.
+- Reason: destructuring lets you specify a default value at the point of assignment (`const [first = fallback] = array`), so completion such as `?? null` becomes unnecessary. It can also take multiple leading elements declaratively in a single statement.
+
+```javascript
+// NG
+const head = segments[0]
+const last = segments[segments.length - 1]
+
+// OK: destructuring for the leading element (with a default), at(-1) for the last
+const [head = ''] = segments
+const last = segments.at(-1)
+```
+
+## Do not casually add if statements
+
+- Do not casually add `if` statements.
+- For a repeatable (iterative, regular) structure, first consider whether "it can be written with a single piece of logic."
+- In particular, branching only on the first element by checking `index` inside a higher-order function violates the principle of "treat all elements of an array equally in higher-order functions."
+
+```javascript
+// NG: branching to special-case only the first element by checking index inside map
+segments
+  .map((it, index) => {
+    if (index === 0) {
+      return it.toLowerCase()
+    }
+
+    return this.capitalizeSegment({ segment: it })
+  })
+  .join('')
+
+// OK: capitalize all elements equally, and lower-case the first character in a single batch step after joining
+return segments
+  .map(it => this.capitalizeSegment({ segment: it }))
+  .join('')
+  .replace(/^./u, it => it.toLowerCase())
+```

--- a/kit/skills/core/hc-test-execution/SKILL.md
+++ b/kit/skills/core/hc-test-execution/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: hc-test-execution
+description: >
+  Run a project's test cases and drive them to green without weakening them — no test skipped,
+  deleted, loosened, or padded with waits to make the suite pass. Use this skill whenever tests are run,
+  whenever a test still fails after an implementation was believed finished, when the user asks to
+  run or fix failing tests, and before claiming an implementation is complete. Writing new tests
+  belongs to the project's test-writing convention.
+---
+
+# Test Execution
+
+A skill for **running the test cases and resolving what they report**.
+
+The failure this skill exists to prevent is not "the tests fail". It is what usually happens next:
+changing the test until it stops failing. A suite that was changed until it passed reports nothing,
+and the next defect ships behind a green run.
+
+## Core principle: a failing test is a result, not an obstacle
+
+The test is a statement about required behavior. When it fails, exactly one of two things is true:
+the behavior is wrong, or the statement is wrong. **Deciding which one — with evidence — is the
+work.** Everything else is just routine detail.
+
+- The default assumption is that the **implementation** is wrong. A test written before the
+  implementation encodes what was required; the implementation is the newer, less-reviewed
+  thing.
+- A test's expectation may be changed **only** when a written acceptance criterion says the
+  expectation is wrong. Not because the implementation disagrees with it — the implementation
+  disagreeing with it is the failure.
+- **Making a red test green is not the goal. Learning what the red test found is the goal.**
+
+## The loop
+
+```
+run the whole suite
+      │
+      ▼
+any failure? ──no──▶ report the run's own summary ──▶ done
+      │yes
+      ▼
+take ONE failure
+      │
+      ▼
+read its actual output (message, diff, stack, the assertion that failed)
+      │
+      ▼
+classify it  ──────▶  see references/failure-triage.md
+      │
+      ▼
+fix the thing the classification names — never the test unless the class is "test defect"
+      │
+      ▼
+re-run that one test ──fails──▶ back to reading the output (do NOT try a second change on top)
+      │passes
+      ▼
+re-run the whole suite ──▶ back to the top
+```
+
+- **One failure at a time.** Changing three things and re-running tells you nothing about which
+  change did what, and routinely leaves two of them wrong.
+- **Re-run the whole suite after every fix**, not only the test that was failing. A fix that
+  breaks two other tests is a worse state than the one it started from, and only the full run
+  shows it.
+- **Never stack a second change on a failed attempt.** Revert the attempt, re-read the output,
+  then change one thing.
+
+## Before running anything
+
+1. **Discover how this project runs its tests.** Read `package.json` scripts and the test
+   configuration. Use the project's own command; do not invent one.
+2. **Discover whether the project has more than one suite and whether order matters.** Many
+   projects separate tests that touch no persistent state from tests that write to a store, and
+   require them to run in a defined order. Running them the wrong way produces failures that
+   have nothing to do with the code.
+3. **Discover what the suite needs to be present** — an environment file, a database, a
+   migration applied, a seed set loaded. A missing prerequisite produces failures that look like
+   defects.
+4. **Run the suite once before changing anything**, to establish which failures were already
+   there. A pre-existing failure attributed to the current change wastes the whole session.
+5. **Size the run to the machine, not to its listed specifications.** Most runners execute test
+   files in **parallel workers** — one per core by default — and each worker is a full process using
+   its own memory. That default assumes an idle machine; a real one is running an editor, a browser,
+   a local database, and sometimes a full E2E stack, all using memory before the suite starts.
+   Before a full run, account for what else is resident and how much memory and CPU are **actually
+   free** — not how much is installed. **When the machine is constrained, dial the parallelism
+   down** (the runner's max-workers lever, halved and re-run) **or run serially** (the runner's
+   in-band / single- worker mode) rather than letting the operating system kill a worker — or
+   another process — under the load. A serial run that finishes beats a parallel one that dies
+   halfway. The concrete flags and the way to weigh workers against available memory belong to the
+   project's test-running convention; the principle here is to **look at the machine before choosing
+   the parallelism**, not after it dies.
+
+## Read the actual output
+
+- Read the failure message, the expected-versus-received diff, the failing assertion and the
+  stack frame in the project's own code. All four.
+- **Infer the cause from the output, not from the test's name.** The name says what it was supposed
+  to check; the output says what happened.
+- **Never act on remembered output.** If the output has scrolled away, run the single test again
+  and read it.
+- When the message is unclear, get more signal before changing code: run the one test in
+  isolation, print the actual value, or run with the project's verbose option. Guessing costs
+  more than one extra run.
+
+## Changing a test is a specification decision
+
+A test expectation may be changed only in these two cases, and the report must say which.
+
+| Case | What must be true |
+| :-- | :-- |
+| The test contradicts a written acceptance criterion | Quote the criterion id and its text in the report. The test was wrong; the implementation may be right |
+| The specification itself changed | The requirement document records the change. Until it does, the test stands |
+
+In every other case the test stands and the implementation changes. "The implementation is
+obviously right and the test is out of date" is not one of the two cases — it is the
+rationalization this rule exists to stop.
+
+## Prohibited ways to make a test pass
+
+These are never acceptable, including "temporarily". See
+[prohibited-fixes.md](./references/prohibited-fixes.md) for what to do instead in each case.
+
+- Skipping, disabling, commenting out or deleting a failing test.
+- Loosening an assertion — asserting truthiness where a value was asserted, removing a field
+  from an expected object, widening a matcher until it stops discriminating.
+- Widening a timeout, adding a wait, or adding a retry to make an intermittent failure stop.
+- Editing fixture or seed data so that it matches the behavior the implementation happens to
+  have.
+- Mocking or stubbing the very thing under test, or stubbing a collaborator so that the failing
+  path is no longer exercised.
+- Adding a branch to the implementation that exists only to satisfy the test.
+- Marking a test as expected-to-fail.
+
+**Breaking the letter of these rules breaks their spirit too.** A suite whose failures were silenced
+is worse than no suite, because it is believed.
+
+## Rationalization table
+
+Every one of these appears when a suite will not go green. Each one means: stop and triage.
+
+| Rationalization | Reality |
+| :-- | :-- |
+| "The test is out of date" | Then a written criterion says so. Quote it, or the test stands |
+| "The implementation is obviously correct" | Obvious is what the test is there to check. Read the criterion |
+| "It's flaky, just re-run it" | Flaky means order-dependent or racing. That is a defect, in the test or the code. Diagnose it |
+| "I'll skip it and come back" | Nobody comes back. A skipped test is a deleted test with extra steps |
+| "It only fails on CI" | Then the difference between the environments is the finding. Find it |
+| "The assertion is too strict" | The assertion is the specification. Strictness is the feature |
+| "I'll widen the timeout, the machine is slow" | Timeouts hide races. Find what is not being waited for |
+| "Just this one test, the rest pass" | The rest passing is what makes the one failure informative |
+| "It's a pre-existing failure, not mine" | Say so in the report, with the run that proves it. Do not silence it |
+| "Nobody will notice" | The next defect behind this test will slip by too. That is the cost |
+
+## Red flags — stop and triage
+
+- Editing a test file before having classified the failure.
+- Reaching for `.skip`, `.todo`, a longer timeout or a retry.
+- Copying the received value from the failure output into the expected value.
+- Making a change without having read the failure output in this session.
+- Re-running "to see if it passes this time".
+- Two or more edits since the last run.
+
+**All of these mean: revert the edit, read the output, classify the failure.**
+
+## Reporting the run
+
+Build the report from the run's own output, not from memory.
+
+1. **The command that was run**, exactly as executed, and which suite it covers.
+2. **The run's own summary line** — the suite and test counts as the runner printed them.
+   Paste it; do not paraphrase it.
+3. **Per failure resolved**: the test, the classification, what was actually wrong, what was
+   changed, and — when a test expectation was changed — the acceptance criterion id that
+   justified it.
+4. **Failures still open**, with their classification and what is needed. Never omit these.
+5. **Pre-existing failures**, separated from the ones this work caused.
+
+State that the suite passes only when the run's summary is in the report. **A claim of green without
+the output is an unverified claim**, and the whole point of running the tests was to stop making
+unverified claims.
+
+## Detail files
+
+- [failure-triage.md](./references/failure-triage.md) — the classification step: symptoms, what
+  each class means, what to inspect, and how to confirm the classification before acting.
+- [prohibited-fixes.md](./references/prohibited-fixes.md) — each prohibited move, what it hides,
+  and the correct handling of the situation that tempts it.

--- a/kit/skills/core/hc-test-execution/references/failure-triage.md
+++ b/kit/skills/core/hc-test-execution/references/failure-triage.md
@@ -1,0 +1,110 @@
+# Failure Triage
+
+Classifying a failure before changing anything. Triage is the step that decides **what** gets
+changed; skipping it is how a test ends up edited to match a defect.
+
+## The four classes
+
+| Class | The failure means | What changes |
+| :-- | :-- | :-- |
+| Implementation defect | The behavior is wrong | The implementation |
+| Test defect | The statement of required behavior is wrong | The test — only against a written acceptance criterion |
+| Environment or fixture problem | Neither is wrong; the run was not set up as the test requires | The setup, the fixture or the command |
+| Order-dependent or racing | The test passes and fails depending on what ran before it or on timing | Whichever of the two owns the shared state or the missing wait |
+
+**Default to implementation defect** — leave it only with the evidence each other class requires
+below.
+
+## Confirming each class
+
+### Implementation defect
+
+Symptoms: the expected-versus-received diff shows the code produced a different value, a
+different error or no effect at all; the test is unchanged in this diff; the code path in the
+stack is code the current work touched.
+
+Confirm by tracing the path from the test's entry point to the value it asserts, and finding the
+step where the value diverges from the requirement. **Naming the step is the confirmation.** A
+failure attributed to the implementation without a named step is a guess.
+
+### Test defect
+
+Symptoms: the implementation produces what the acceptance criterion states, and the test asserts
+something else.
+
+Confirm by quoting the acceptance criterion. There is no other confirmation.
+
+| Situation | Class |
+| :-- | :-- |
+| The criterion says X, the test asserts Y, the code does X | Test defect — fix the test, cite the criterion id |
+| The criterion says X, the test asserts X, the code does Y | Implementation defect |
+| No criterion covers the point | **Not a test defect.** The specification is silent; get it decided before changing either side |
+| The criterion is ambiguous between the two readings | Not a test defect. Raise the ambiguity as an open question against the requirement |
+
+A test defect also covers tests that are wrong in a way unrelated to the expectation: a fixture
+built inconsistently inside the test, an assertion on the wrong subject, an `await` missing so
+the assertion runs before the effect. These are fixed in the test, and the report says what was
+wrong with it.
+
+### Environment or fixture problem
+
+Symptoms: the failure names a connection, a missing table or column, a missing configuration
+value, a missing file, an authentication error, or a value that is absent rather than wrong;
+many unrelated tests fail together in the same way; the same test passes on another machine or
+after a setup step.
+
+Confirm by finding the missing prerequisite: a migration not applied, a seed set not loaded, an
+environment file not present, a service not running, a stale build artefact, a dependency not
+installed after a lockfile change.
+
+- Fix the setup, not the test. A test changed to tolerate a missing prerequisite stops checking
+  the thing the prerequisite is for.
+- If the prerequisite is undocumented, that is itself a finding worth reporting — the next
+  person will lose the same time.
+- If the fixture data is genuinely wrong for the test's purpose, fixing the fixture is
+  legitimate. Editing the fixture so the assertion matches the code's current output is not; see
+  the prohibited-fixes reference.
+
+### Order-dependent or racing
+
+Symptoms: the test passes alone and fails in the suite, or the reverse; the failure moves
+between runs; the failure involves a value from a previous test's data; the failure mentions a
+timeout; the run order changed and the failures changed with it.
+
+Confirm by running the test alone, then running it after the suite that precedes it. Two runs
+with different outcomes confirm the class.
+
+Then find the actual owner of the problem:
+
+| Cause | Where the fix belongs |
+| :-- | :-- |
+| A test leaves data behind that another test reads | The test that leaves it — clean up what it created |
+| Two tests write the same record, row or key | The tests — give each its own identifiers |
+| A test depends on running after another | The dependency itself — make each test set up what it needs |
+| The assertion runs before the effect completes | The test — wait for the actual condition, not for a set amount of time |
+| The implementation races with itself | The implementation — this is a real defect that the suite happened to expose |
+
+**A test that fails intermittently has found something.** The only wrong response is to re-run
+until it passes.
+
+## Multiple failures at once
+
+- Look for the shared cause first. Twenty failures with the same message are one problem, and
+  fixing it clears all twenty.
+- Fix in dependency order: environment problems first (they mask everything), then the
+  implementation defect that the most tests point at, then the rest one at a time.
+- Do not open twenty investigations. Classify all of them, group them, then work one group.
+
+## Recording the triage
+
+For each failure, record before changing anything:
+
+```
+- Test: <the test's full name>
+- Output: <the assertion that failed, expected vs received>
+- Class: <implementation defect | test defect | environment | order-dependent>
+- Confirmation: <the diverging step, the criterion id, the missing prerequisite, or the two runs>
+```
+
+The confirmation line is what makes the change afterwards defensible. A change made without it
+looks, later, exactly like editing the test until it passed.

--- a/kit/skills/core/hc-test-execution/references/prohibited-fixes.md
+++ b/kit/skills/core/hc-test-execution/references/prohibited-fixes.md
@@ -1,0 +1,131 @@
+# Prohibited Fixes
+
+Each move below makes a red suite green while destroying what the suite was for. For each one:
+what it hides, and the correct handling of the situation that tempts it.
+
+None of these is acceptable "temporarily". A temporary silencing that is never revisited is the same
+as a permanent one, and in practice it never gets revisited.
+
+## Skipping, disabling or deleting a test
+
+**Hides:** the entire behavior the test covered. Nothing will report it again.
+
+**Tempting situation:** the failure is hard, and the rest of the suite is green.
+
+**Correct handling:** classify the failure and fix what the classification names. If it genuinely
+cannot be fixed now, the test stays failing and the report says so, with the classification and
+what is needed. A visible red test is information; a skipped test is a lie the next reader
+believes.
+
+The only legitimate removal of a test is the removal of the requirement it covers — recorded as a
+withdrawal in the requirement document, not decided on the spot just because the test is
+inconvenient.
+
+## Loosening an assertion
+
+**Hides:** the difference between the value that was required and the value the code produces.
+
+Examples: asserting that something is truthy where a value was asserted; dropping a field from
+an expected object; replacing an exact match with a pattern that matches anything; asserting a
+count instead of the contents; asserting "it threw" instead of which error.
+
+**Tempting situation:** the received value is *nearly* right, and the difference looks
+incidental.
+
+**Correct handling:** the difference is the finding. Either the code produces the wrong value — an
+implementation defect — or the acceptance criterion says the expected value is wrong, in which case
+the expectation is corrected to the criterion's value, exactly, and the criterion id goes in the
+report. Never widen an assertion; it is corrected to a different exact statement or it stands.
+
+## Pasting the received value into the expectation
+
+**Hides:** everything. The test now asserts that the code does what the code does.
+
+**Tempting situation:** the diff is large and comparing it by hand is tedious.
+
+**Correct handling:** read the diff field by field and decide, per field, which side is wrong. If
+the received value is correct against the criteria, updating the expectation to it is legitimate
+— but only after that judgment, and the report names the criterion. Copying first and judging
+never is the failure.
+
+## Widening a timeout, adding a wait, adding a retry
+
+**Hides:** a race, a missing await, an unbounded operation, or a genuine performance regression.
+
+**Tempting situation:** it passes on a fast machine and fails on a slow one.
+
+**Correct handling:** find what is not being waited for. A test should wait for the **condition**
+it needs — a record present, a status changed, a queue drained — not for an amount of time. A
+duration that "usually works" fails under load, and it fails in the run nobody is watching.
+
+A retry is worse than a wait: it makes an intermittent defect invisible while leaving it in the
+product.
+
+## Editing fixture or seed data to match the behavior
+
+**Hides:** the defect, by moving the goalposts to where the ball landed.
+
+**Tempting situation:** the code returns a different record than expected, and the fixture is
+easier to change than the query.
+
+**Correct handling:** decide what the fixture is *for*. Fixture data exists to put the system in
+the state the acceptance criterion names. If it does not represent that state, fixing it is
+correct — and the fix is derived from the criterion, not from the code's output. If it does
+represent that state, the code is wrong.
+
+Signals that the fixture is being bent rather than fixed: the change makes the data less
+realistic; the change removes the case that made the test interesting; the change is to the one
+record the failing test reads and to nothing else.
+
+## Mocking or stubbing the thing under test
+
+**Hides:** the behavior entirely. The test now checks the mock.
+
+**Tempting situation:** the real collaborator is awkward to set up, and stubbing it makes the
+failure disappear.
+
+**Correct handling:** stub what the test is *not* about — external services, clocks, randomness,
+transport. Never stub the unit under test, and never stub a collaborator in a way that removes
+the path the assertion is about. If the setup is genuinely too awkward, that awkwardness is a
+design finding worth reporting, not a license to stub past it.
+
+## Adding a branch to the implementation for the test
+
+**Hides:** nothing at first — it ships a behavior that exists only because a test asked for it.
+
+Examples: a check for a value that only the fixture uses; a branch on an environment flag that
+makes the tested path behave differently under test; a special case for the exact input the test
+supplies.
+
+**Tempting situation:** the general fix is large and the test only exercises one input.
+
+**Correct handling:** implement the behavior the criterion states, for every input in its range.
+A special case that satisfies the test and nothing else means the product does not have the
+behavior — only the test run does.
+
+## Marking a test as expected-to-fail
+
+**Hides:** the failure, and additionally inverts the signal — when the defect is fixed, the suite
+goes red.
+
+**Correct handling:** leave it failing and report it. A failing test with a classification in the
+report is exactly as visible as it should be.
+
+## Changing the run command to exclude the failure
+
+**Hides:** the test, the file, or the whole suite it lived in — usually without anyone noticing
+that the count dropped.
+
+Examples: narrowing the test path in the script, adding an ignore pattern, running only the
+files that were touched and reporting that as the suite.
+
+**Correct handling:** the suite the project defines is the suite that must pass. Running a subset
+while working is fine; **reporting a subset as the run is not**. The report names the command
+that was executed, so a narrowed command is visible in it — which is why the report format
+requires the command verbatim.
+
+## The one legitimate change to a passing bar
+
+Raising the bar is always allowed: making an assertion stricter, adding a case, adding a test for
+a criterion that had none. If a change to a test makes the suite able to detect *more*, it is not
+one of these moves.

--- a/kit/skills/core/hc-workflows/SKILL.md
+++ b/kit/skills/core/hc-workflows/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: hc-workflows
+description: "Development workflow procedural rules. Defines how to proceed with implementation and the steps that must always be performed before committing / before completion."
+---
+
+# Workflows
+
+Procedural rules related to the development workflow.
+
+## How to proceed with implementation
+
+- Before proceeding with an implementation, consult the skills it requires.
+- Follow this order.
+
+1. Design the class composition of the feature as a whole
+2. Design the member composition of each class
+3. Write the tests
+4. Implement the class members
+5. Commit the tests one class at a time
+6. Commit per class
+
+## Before committing
+
+- Before committing, pass `npx eslint <path> <path> …`, naming the files the commit touches.
+  Every commit leaves the tree lint-clean. Lint the files, not the repository — `npm run lint`
+  walks the whole tree and is too slow to sit in front of every commit.
+- **`npm test` is not a gate on every commit.** Step 5 commits a class's tests before step 6
+  commits its implementation, so that commit fails the suite when it is checked out on its own.
+  That failure is the assertion the test commit makes. Staging the implementation alongside the
+  tests to keep the suite green destroys both the assertion and the split.
+- Run the commit's own tests all the same — `npm test -- <path> <path> …` — and **read the
+  failure**: it must fail on the behavior the tests assert, not on a typo, a bad import or a
+  missing fixture. A test commit that is red for the wrong reason is a defect; a test commit
+  that is green asserts nothing. Note that jest reads those arguments as **regular expressions**
+  matched against the whole test path, not as literal paths, so a pattern selects every file it
+  matches — unlike the eslint arguments above, which are paths.
+- Follow the git commit convention before writing a commit message, and before deciding how to split working-tree changes into commits. It resolves which message format the project uses and defines what belongs in a single commit.
+
+## Before completing implementation
+
+- Pass `npx eslint <path> <path> …` over every file the work touched, and pass `npm test` over
+  the **whole suite**, before completing the implementation. Narrowing the run to the files just
+  changed here would hide the tests this work broke elsewhere. This is where the suite must be
+  green — step 6 is the commit that turns the tests of step 5 green. Do not consider the
+  implementation complete while either one is failing.


### PR DESCRIPTION
# Why

* Close #5

# How

* Copy `kit/skills/core/` from `hora-skills` unchanged — 35 skills, the same paths and the same contents
* Keep the domain directory, so `flatten`'s build only needs its `DOMAIN_PREFIX` narrowed later