### PR TITLE
🏗️ Add the flatten build and the skill-name audit

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: audit
+description: "Repository-specific check that every skill under kit/skills/ sits one level below the core/ domain directory, carries its `hc-` prefix, and declares a `name:` equal to its own folder name — the same rules the flatten build aborts on, reported all at once with a non-zero exit for CI. Use before committing a new, renamed or moved skill. It reports only; it renames and moves nothing, and it checks no frontmatter field other than `name:`."
+---
+
+# Audit
+
+A skill's folder name is its `name:` and the folder name it is installed under — one string, three places. Consuming repositories install every skill of this library, and of its sibling libraries — `hora-skills-renchan` (`backend/`, `hb-`) and `hora-skills-furo` (`frontend/`, `hf-`) — side by side under `.claude/skills/`, so all of those names live in **one flat namespace**, and the source layout is what protects it: the `core/` domain directory, one level of skill folders inside it, the `hc-` prefix that no sibling library uses, and a filesystem that will not hold two folders of one name in one directory.
+
+That protection is only as real as the layout. A skill placed one directory deeper, a `name:` edited without renaming its folder, a folder renamed without editing `name:` — none of these look wrong in the file they occur in, and each breaks the one guarantee the whole scheme rests on. This audit makes the state of the layout visible from outside any single file.
+
+## What is checked
+
+For every entry directly under `kit/skills/core/`:
+
+- **A missing `core/` directory, or an entry directly under `kit/skills/` that is not it, is a failure.** This library holds the one domain, and an entry outside it carries no prefix of this library and has no place in the output.
+- **An entry under the domain that is not a directory, or a directory with no `SKILL.md` directly inside it, is a failure.** Only skill folders belong there, and a folder with no `SKILL.md` installs nothing.
+- **A `SKILL.md` anywhere below a skill folder's own top level is a failure.** The one-level layout is what makes the folder name the skill name; a skill nested inside another has no name of its own. A skill folder's `references/` and `scripts/` subdirectories are its own files, never more skills.
+- **A folder name that is not `hc-`/`hb-`/`hf-` followed by 1–61 characters of `[a-z0-9-]` is a failure.** The name is joined onto `dist/skills/` as a path segment, so a value carrying `/` or `..` would land the folder somewhere else entirely; 64 characters is the limit an installed skill name has to stay within, of which the prefix takes 3. A single case keeps two names from folding onto one folder on a case-insensitive filesystem (macOS, Windows default).
+- **A prefix that does not match the folder's domain is a failure** — `hb-` under `core/` makes the name lie about where the skill lives, and it claims a name that belongs to the renchan backend library; it is the prefix, not the directory, that a consuming repository ever sees. All three prefixes pass the name rule, so this is the check that keeps a sibling library's skill from being published by this one.
+- **A `SKILL.md` with no parsable `name:` is a failure**, and **a `name:` that differs from its folder name is a failure.** This last one is the check everything else rests on: the two are one string by convention, and only an enforced comparison keeps them one string in fact.
+
+Duplicate names are not checked, because they cannot occur. Two skills of this library would need two folders of one name in one directory, and a sibling library's skills carry a prefix of their own — so once each `name:` is confirmed equal to its folder name, uniqueness follows from the filesystem rather than from a comparison.
+
+Nothing else is checked here. Description length, quoting, and the rest of how a `SKILL.md` is written belong to the skill-writing convention, which owns them.
+
+The walk starts at `kit/skills/` and goes nowhere else. This repository's own skills under `.claude/skills/` — this audit and the flatten build — are tooling for maintaining the library, not library content: they are never installed into a consuming repository, so they never enter the flat namespace being protected here, and none of the rules above apply to them. That is why they are free to carry an unprefixed one-word name of their own.
+
+These are exactly the failures the flatten build aborts on, and they are stated identically in both places on purpose. The build enforces them because a violation would destroy or misplace its output; this audit enforces them so a CI job can reject the commit before anyone runs a build. Neither is a substitute for the other, so the rule is written out in both rather than shared through an import that would tie one skill's script to the other's — and a test pins the two copies of the name pattern, and the two copies of the prefix table, to each other, so changing either in one place alone fails.
+
+Every problem found is reported, grouped by kind, in one run: fixing a layout mistake often surfaces the next one, and a report that stops at the first failure would take as many runs as there are mistakes.
+
+## Running
+
+```
+npm run skill-names
+```
+
+Or directly:
+
+```
+node .claude/skills/audit/scripts/audit.js
+```
+
+It exits `0` when every skill sits one level under the domain directory and declares a `name:` equal to its folder name, and `1` on any of the failures above, so it can gate a commit or a CI job.
+
+## Resolving a mismatch
+
+For a `name:` that disagrees with its folder name, decide which of the two is the name the skill should ship under, then make the other match it. The folder name is what a consuming repository installs and invokes, so the choice is about the installed command name, not about tidiness in the tree.
+
+For a skill in the wrong place — nested too deep, or carrying a prefix this library does not own — move the folder to the library its prefix names, or change both the prefix and `name:` to `hc-`. Renaming is the deliberate part: an installed skill's name is what consuming repositories invoke, so a rename is a breaking change for them.
+
+Renaming a skill breaks no references inside this library: the skill-writing convention prohibits referring to another skill by name or by relative path, requiring a descriptive reference to the concept instead. That prohibition exists so a rename stays local to the one folder.

--- a/.claude/skills/audit/scripts/audit.js
+++ b/.claude/skills/audit/scripts/audit.js
@@ -1,0 +1,210 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+const sourceRoot = join(repoRoot, 'kit/skills')
+const namePattern = /^h[cbf]-[a-z0-9-]{1,61}$/u
+
+const DOMAIN_PREFIX = {
+  core: 'hc',
+}
+
+/**
+ * Read the `name:` value from a SKILL.md's frontmatter.
+ *
+ * @param {string} skillMdPath - Path to the SKILL.md to read.
+ * @returns {string | null} The declared name, or null when absent or unparsable.
+ */
+function readSkillName (skillMdPath) {
+  const content = readFileSync(skillMdPath, 'utf8')
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/u)
+
+  if (!frontmatterMatch) {
+    return null
+  }
+
+  const nameMatch = frontmatterMatch[1].match(/^name:[ \t]*(.*)$/mu)
+
+  if (!nameMatch) {
+    return null
+  }
+
+  const value = nameMatch[1]
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/u, '$2')
+    .trim()
+
+  return value === ''
+    ? null
+    : value
+}
+
+/**
+ * Find every SKILL.md below a skill directory's own top level.
+ *
+ * @param {string} dir - Directory to search.
+ * @param {Array<string>} segments - Path segments accumulated so far, relative to the skill directory.
+ * @returns {Array<string>} Paths of nested SKILL.md files, relative to the skill directory.
+ */
+function findNestedSkillMds (
+  dir,
+  segments
+) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(it => it.isDirectory())
+    .flatMap(it => {
+      const entries = readdirSync(join(dir, it.name), { withFileTypes: true })
+      const nested = entries.some(entry => entry.isFile() && entry.name === 'SKILL.md')
+        ? [[...segments, it.name, 'SKILL.md'].join('/')]
+        : []
+
+      return [
+        ...nested,
+        ...findNestedSkillMds(join(dir, it.name), [...segments, it.name]),
+      ]
+    })
+}
+
+/**
+ * Read one entry of a domain directory.
+ *
+ * @param {string} domain - Domain directory name directly under kit/skills/ (e.g. 'core').
+ * @param {import('node:fs').Dirent} dirent - Child of the domain directory.
+ * @returns {{domain: string, folderName: string, path: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}} The entry.
+ */
+function readDomainEntry (
+  domain,
+  dirent
+) {
+  const absolutePath = join(sourceRoot, domain, dirent.name)
+  const path = `kit/skills/${domain}/${dirent.name}`
+
+  if (!dirent.isDirectory()) {
+    return {
+      domain,
+      folderName: dirent.name,
+      path,
+      isDirectory: false,
+      hasSkillMd: false,
+      name: null,
+      nestedSkillMds: [],
+    }
+  }
+
+  const hasSkillMd = readdirSync(absolutePath, { withFileTypes: true })
+    .some(entry => entry.isFile() && entry.name === 'SKILL.md')
+
+  return {
+    domain,
+    folderName: dirent.name,
+    path,
+    isDirectory: true,
+    hasSkillMd,
+    name: hasSkillMd
+      ? readSkillName(join(absolutePath, 'SKILL.md'))
+      : null,
+    nestedSkillMds: findNestedSkillMds(absolutePath, []),
+  }
+}
+
+/**
+ * Read every entry of one domain directory.
+ *
+ * @param {string} domain - Domain directory name directly under kit/skills/ (e.g. 'core').
+ * @returns {Array<{domain: string, folderName: string, path: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}>} One entry per child of the domain directory.
+ */
+function readDomainEntries (domain) {
+  return readdirSync(join(sourceRoot, domain), { withFileTypes: true })
+    .map(it => readDomainEntry(domain, it))
+}
+
+const domains = Object.keys(DOMAIN_PREFIX)
+
+const missingDomains = domains.filter(it => !existsSync(join(sourceRoot, it)))
+
+const unexpectedRootEntries = readdirSync(sourceRoot, { withFileTypes: true })
+  .filter(it => !(it.isDirectory() && domains.includes(it.name)))
+  .map(it => `kit/skills/${it.name}`)
+
+const skillEntries = domains
+  .filter(it => !missingDomains.includes(it))
+  .flatMap(it => readDomainEntries(it))
+
+const problemGroups = [
+  {
+    heading: 'Missing domain directory',
+    lines: missingDomains.map(it => `kit/skills/${it}/`),
+  },
+  {
+    heading: 'Not the core domain directory',
+    lines: unexpectedRootEntries,
+  },
+  {
+    heading: 'Not a skill directory',
+    lines: skillEntries
+      .filter(it => !it.isDirectory)
+      .map(it => it.path),
+  },
+  {
+    heading: 'No SKILL.md',
+    lines: skillEntries
+      .filter(it => it.isDirectory && !it.hasSkillMd)
+      .map(it => `${it.path}/`),
+  },
+  {
+    heading: 'Nested skill below a skill directory',
+    lines: skillEntries
+      .flatMap(it => it.nestedSkillMds.map(nested => `${it.path}/${nested}`)),
+  },
+  {
+    heading: `Folder name is not ${namePattern.source}`,
+    lines: skillEntries
+      .filter(it => it.isDirectory && !namePattern.test(it.folderName))
+      .map(it => `${it.path}/`),
+  },
+  {
+    heading: 'Prefix does not match the domain',
+    lines: skillEntries
+      .filter(it =>
+        it.isDirectory
+        && namePattern.test(it.folderName)
+        && !it.folderName.startsWith(`${DOMAIN_PREFIX[it.domain]}-`))
+      .map(it => `${it.path}/  (expected ${DOMAIN_PREFIX[it.domain]}-)`),
+  },
+  {
+    heading: 'Missing name:',
+    lines: skillEntries
+      .filter(it => it.hasSkillMd && it.name === null)
+      .map(it => `${it.path}/SKILL.md`),
+  },
+  {
+    heading: 'name: does not match the folder name',
+    lines: skillEntries
+      .filter(it => it.name !== null && it.name !== it.folderName)
+      .map(it => `${it.path}/SKILL.md  (declares ${it.name})`),
+  },
+]
+  .filter(it => it.lines.length > 0)
+
+process.stdout.write(`Checked ${skillEntries.length} skills under kit/skills/\n`)
+
+problemGroups.forEach(({ heading, lines }) => {
+  process.stdout.write(`\n${heading}: ${lines.length}\n\n`)
+
+  lines.forEach(line => {
+    process.stdout.write(`    ${line}\n`)
+  })
+})
+
+if (problemGroups.length === 0) {
+  process.stdout.write(
+    'Every skill sits one level under its domain and declares a name: equal to its folder name\n'
+  )
+}
+
+process.exit(
+  problemGroups.length > 0
+    ? 1
+    : 0
+)

--- a/.claude/skills/flatten/SKILL.md
+++ b/.claude/skills/flatten/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: flatten
+description: "Repository-specific build convention: kit/skills/ holds exactly one domain directory (core/), containing one level of skill folders named hc-*, and the build copies those folders into dist/skills/ unchanged — dropping only the domain level — to produce the flat .claude/skills/ layout that consuming repositories install. Use when rebuilding the dist/ output, or when adding, renaming or placing a skill under kit/skills/."
+---
+
+# Flatten
+
+Consuming repositories install skills as a single flat list directly under `.claude/skills/`, with no domain subdirectories. `dist/skills/` is the build output of this repository that already has that flat shape, ready to be installed as-is.
+
+`kit/skills/` keeps the domain level for whoever maintains it, and each skill's folder is already named exactly as it will be installed. Flattening is therefore the whole of the build: drop the domain level, copy everything else through untouched.
+
+## Source layout
+
+`kit/skills/` contains exactly one directory, and nothing else:
+
+| Domain directory | Prefix | What it holds |
+|---|---|---|
+| `core/` | `hc-` | Conventions and procedures that apply to any project, regardless of stack |
+
+Keeping the domain level in a library that has one domain is deliberate: it is the layout its sibling libraries use — `hora-skills-renchan` (`backend/`, `hb-`) and `hora-skills-furo` (`frontend/`, `hf-`) — so a skill moves between them by moving its folder, and the build and the audit read the same tree in every one of them.
+
+The domain directory contains skill folders and nothing else. Every skill is therefore at exactly this depth:
+
+```
+kit/skills/core/<name>/SKILL.md
+```
+
+A skill folder may hold its own subdirectories (`references/`, `scripts/`), but no `SKILL.md` below its top level — those subdirectories are the skill's own files, never more skills. There are no intermediate grouping directories: no `core/declarations/classes/`, no `core/classes/members/`.
+
+### The folder name is the skill's name
+
+A skill folder's name is the skill's `name:`, and the folder name it gets under `dist/skills/`, all one string:
+
+```
+kit/skills/core/hc-code-review/   name: hc-code-review   →   dist/skills/hc-code-review/
+```
+
+The prefix is part of the name: the skill is invoked as `/hc-code-review`. The `h` stands for **hora**, from Hora Kit — the Open Reach Tech product this skill library is part of — and the second character is the domain: `c` for `core`, against `b` for the renchan backend library and `f` for the Furo frontend one.
+
+Two characters buy two things. A consuming repository installs these skills side by side with its own, and with the sibling libraries' — a project equips whichever domains it works in — all in one flat list, and the prefix is what tells a reader at a glance which skills came from this library. And because every prefix belongs to exactly one library and a filesystem cannot hold two folders of one name in one directory, no two installed skills can end up with the same name — the flat namespace is protected by the source layout itself, with nothing to check.
+
+## The build
+
+```
+node .claude/skills/flatten/scripts/build.js
+```
+
+It validates the whole source tree first (below), then deletes `dist/skills/` outright and recreates it: `dist/` is a function of the current source alone. Without the deletion, a skill renamed or removed at the source would keep its stale folder in `dist/` indefinitely, and the build would go on shipping a skill that no longer exists — a failure invisible in a diff, because nothing about the stale folder changes.
+
+Each skill folder is then copied to `dist/skills/<folder name>/` **byte for byte**. Nothing is rewritten:
+
+- The `name:` line stays. The field and the folder name are the same string by construction, so there is no second, divergent source of truth to remove.
+- No source note is appended. The source path is `kit/skills/core/<name>/`, and the prefix names the domain, so an installed `hc-code-review/` already says where it came from. A footer repeating it would be text to maintain that carries nothing.
+
+Validation runs before the deletion, so a source tree that cannot produce a valid flat namespace leaves the previous output untouched rather than half-replaced. Every problem found is reported at once, not one per run:
+
+| Aborts the build | Why |
+|---|---|
+| An entry directly under `kit/skills/` that is not the `core/` domain directory | It belongs to no domain of this library, so it has no place in the output. |
+| A non-directory entry directly under the domain | Only skill folders belong there. |
+| A skill folder with no `SKILL.md` | There is nothing to install. |
+| A `SKILL.md` below a skill folder's top level | The one-level layout is the guarantee that the folder name is the skill name; a nested skill would have no name of its own. |
+| A folder name that is not `hc-`/`hb-`/`hf-` followed by 1–61 characters of `[a-z0-9-]` | The name is joined onto `dist/skills/` as a path segment, so a value containing `/` or `..` would put the folder somewhere other than directly under `dist/skills/`. 64 characters is the limit an installed skill name has to stay within, which the 3-character prefix leaves 61 of. |
+| A prefix that does not match the folder's domain (`hb-` under `core/`) | The prefix is the domain, so a mismatch makes the name lie about where the skill lives — and it claims a name that belongs to the renchan backend library. |
+| A `SKILL.md` with no parsable `name:` | Nothing declares what the installed skill is called. |
+| A `name:` that differs from its folder name | This is the check the whole scheme rests on. The two are one string by convention; only an enforced comparison keeps them one string in fact. |
+
+All three prefixes are recognized by the name rule, and it is the domain check that then rejects the two this library does not own — so a skill dropped in from a sibling library is reported as being in the wrong place, not as carrying a broken name.
+
+Restricting names to a single case is what lets the folder-name comparison be exact, and what keeps two names from folding onto one folder on a case-insensitive filesystem (macOS, Windows default).
+
+## Naming a new skill
+
+Choose the name for the reader who sees a flat list of skills and never sees this repository — then create the folder under `kit/skills/core/`, and declare the same string as `name:`.
+
+The existing names came from the source tree as it was before this layout: a nested, topic-subdivided tree flattened one time by an algorithm that took the domain and the last two path segments, dropped the classifying words in between, and shortened a few of them. The conventions that fell out of it are worth keeping for new names:
+
+| Convention | Examples |
+|---|---|
+| Drop structural words that only place a skill within its domain (`declarations`, `shared`, `members`) | `hc-async`, `hc-accessors`, `hc-methods` |
+| Keep a classifying word when it is what a reader would search for | `hc-classes-constructor`, `hc-modules-exports` |
+| Two or more words read better as a command name than one | `hc-code-review` over `hc-review` |

--- a/.claude/skills/flatten/scripts/build.js
+++ b/.claude/skills/flatten/scripts/build.js
@@ -1,0 +1,193 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+const sourceRoot = join(repoRoot, 'kit/skills')
+const outputRoot = join(repoRoot, 'dist/skills')
+const namePattern = /^h[cbf]-[a-z0-9-]{1,61}$/u
+
+const DOMAIN_PREFIX = {
+  core: 'hc',
+}
+
+/**
+ * Read the `name:` value from a SKILL.md's frontmatter.
+ *
+ * @param {string} skillMdPath - Path to the SKILL.md to read.
+ * @returns {string | null} The declared name, or null when absent or unparsable.
+ */
+function readSkillName (skillMdPath) {
+  const content = readFileSync(skillMdPath, 'utf8')
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/u)
+
+  if (!frontmatterMatch) {
+    return null
+  }
+
+  const nameMatch = frontmatterMatch[1].match(/^name:[ \t]*(.*)$/mu)
+
+  if (!nameMatch) {
+    return null
+  }
+
+  const value = nameMatch[1]
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/u, '$2')
+    .trim()
+
+  return value === ''
+    ? null
+    : value
+}
+
+/**
+ * Find every SKILL.md below a skill directory's own top level.
+ *
+ * @param {string} dir - Directory to search, relative paths accumulated from it.
+ * @param {Array<string>} segments - Path segments accumulated so far, relative to the skill directory.
+ * @returns {Array<string>} Paths of nested SKILL.md files, relative to the skill directory.
+ */
+function findNestedSkillMds (
+  dir,
+  segments
+) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(it => it.isDirectory())
+    .flatMap(it => {
+      const entries = readdirSync(join(dir, it.name), { withFileTypes: true })
+      const nested = entries.some(entry => entry.isFile() && entry.name === 'SKILL.md')
+        ? [[...segments, it.name, 'SKILL.md'].join('/')]
+        : []
+
+      return [
+        ...nested,
+        ...findNestedSkillMds(join(dir, it.name), [...segments, it.name]),
+      ]
+    })
+}
+
+/**
+ * Read one child of a domain directory.
+ *
+ * @param {string} domain - Domain directory name directly under kit/skills/ (e.g. 'core').
+ * @param {import('node:fs').Dirent} dirent - Child of the domain directory.
+ * @returns {{domain: string, folderName: string, absolutePath: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}} The entry.
+ */
+function readDomainEntry (
+  domain,
+  dirent
+) {
+  const absolutePath = join(sourceRoot, domain, dirent.name)
+
+  if (!dirent.isDirectory()) {
+    return {
+      domain,
+      folderName: dirent.name,
+      absolutePath,
+      isDirectory: false,
+      hasSkillMd: false,
+      name: null,
+      nestedSkillMds: [],
+    }
+  }
+
+  const hasSkillMd = readdirSync(absolutePath, { withFileTypes: true })
+    .some(entry => entry.isFile() && entry.name === 'SKILL.md')
+
+  return {
+    domain,
+    folderName: dirent.name,
+    absolutePath,
+    isDirectory: true,
+    hasSkillMd,
+    name: hasSkillMd
+      ? readSkillName(join(absolutePath, 'SKILL.md'))
+      : null,
+    nestedSkillMds: findNestedSkillMds(absolutePath, []),
+  }
+}
+
+/**
+ * Read every skill directory of one domain.
+ *
+ * @param {string} domain - Domain directory name directly under kit/skills/ (e.g. 'core').
+ * @returns {Array<{domain: string, folderName: string, absolutePath: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}>} One entry per child of the domain directory.
+ */
+function readDomainEntries (domain) {
+  return readdirSync(join(sourceRoot, domain), { withFileTypes: true })
+    .map(it => readDomainEntry(domain, it))
+}
+
+const domains = Object.keys(DOMAIN_PREFIX)
+
+const missingDomains = domains.filter(it => !existsSync(join(sourceRoot, it)))
+
+const unexpectedRootEntries = readdirSync(sourceRoot, { withFileTypes: true })
+  .filter(it => !(it.isDirectory() && domains.includes(it.name)))
+  .map(it => `Unexpected entry directly under kit/skills/: ${it.name}`)
+
+const skillEntries = domains
+  .filter(it => !missingDomains.includes(it))
+  .flatMap(it => readDomainEntries(it))
+
+const issues = [
+  ...missingDomains.map(it => `Missing domain directory: kit/skills/${it}/`),
+
+  ...unexpectedRootEntries,
+
+  ...skillEntries
+    .filter(it => !it.isDirectory)
+    .map(it => `Not a skill directory: kit/skills/${it.domain}/${it.folderName}`),
+
+  ...skillEntries
+    .filter(it => it.isDirectory && !it.hasSkillMd)
+    .map(it => `No SKILL.md: kit/skills/${it.domain}/${it.folderName}/`),
+
+  ...skillEntries
+    .flatMap(it => it.nestedSkillMds
+      .map(nested => `Nested skill: kit/skills/${it.domain}/${it.folderName}/${nested}`)),
+
+  ...skillEntries
+    .filter(it => it.isDirectory && !namePattern.test(it.folderName))
+    .map(it => `Invalid folder name: kit/skills/${it.domain}/${it.folderName}/`),
+
+  ...skillEntries
+    .filter(it =>
+      it.isDirectory
+      && namePattern.test(it.folderName)
+      && !it.folderName.startsWith(`${DOMAIN_PREFIX[it.domain]}-`))
+    .map(it => `Wrong prefix for ${it.domain}/ (expected ${DOMAIN_PREFIX[it.domain]}-): kit/skills/${it.domain}/${it.folderName}/`),
+
+  ...skillEntries
+    .filter(it => it.hasSkillMd && it.name === null)
+    .map(it => `Missing name: kit/skills/${it.domain}/${it.folderName}/SKILL.md`),
+
+  ...skillEntries
+    .filter(it => it.name !== null && it.name !== it.folderName)
+    .map(it => `name: ${it.name} does not match its folder: kit/skills/${it.domain}/${it.folderName}/`),
+]
+
+if (issues.length > 0) {
+  const details = issues
+    .map(it => `  - ${it}`)
+    .join('\n')
+
+  throw new Error(
+    `Cannot flatten kit/skills:\n${details}\n`
+  )
+}
+
+rmSync(outputRoot, { recursive: true, force: true })
+
+mkdirSync(outputRoot, { recursive: true })
+
+skillEntries.forEach(({ absolutePath, folderName }) => {
+  cpSync(
+    absolutePath,
+    join(outputRoot, folderName),
+    { recursive: true }
+  )
+})
+
+process.stdout.write(`Flattened ${skillEntries.length} skills into ${outputRoot}\n`)

--- a/package.json
+++ b/package.json
@@ -3,13 +3,11 @@
   "version": "0.0.0",
   "description": "Distributes the ORT JavaScript coding skills used to develop with Hora Kit.",
   "type": "module",
-  "main": "index.js",
   "files": [
-    "lib/",
-    "types/",
-    "!types/env/**"
+    "dist/",
+    "docs/",
+    "lib/"
   ],
-  "types": "./types/index.d.ts",
   "keywords": [
     "hora",
     "hora-kit",
@@ -17,8 +15,11 @@
     "javascript"
   ],
   "scripts": {
+    "build": "node .claude/skills/flatten/scripts/build.js",
     "l": "npm run lint",
     "lint": "eslint .",
+    "prepack": "npm run build",
+    "skill-names": "node .claude/skills/audit/scripts/audit.js",
     "test": "export NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\"; export NODE_ENV=development; jest"
   },
   "repository": {

--- a/tests/__tests__/skills/domain-prefix.js
+++ b/tests/__tests__/skills/domain-prefix.js
@@ -1,0 +1,32 @@
+import {
+  readFileSync,
+} from 'node:fs'
+import {
+  join,
+} from 'node:path'
+import {
+  fileURLToPath,
+} from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url))
+
+/*
+ * Which prefix belongs to this library's domain is written out in both maintenance
+ * scripts on purpose, so that neither script has to import from the other. This pins
+ * the two copies to one another: changing the table in one place alone fails here.
+ */
+describe('Skill domain prefix table', () => {
+  describe('is declared identically by every script that enforces it', () => {
+    const cases = [
+      { scriptPath: '.claude/skills/audit/scripts/audit.js' },
+      { scriptPath: '.claude/skills/flatten/scripts/build.js' },
+    ]
+
+    test.each(cases)('$scriptPath', ({ scriptPath }) => {
+      const content = readFileSync(join(repoRoot, scriptPath), 'utf8')
+
+      expect(content)
+        .toContain("const DOMAIN_PREFIX = {\n  core: 'hc',\n}")
+    })
+  })
+})

--- a/tests/__tests__/skills/name-pattern.js
+++ b/tests/__tests__/skills/name-pattern.js
@@ -1,0 +1,32 @@
+import {
+  readFileSync,
+} from 'node:fs'
+import {
+  join,
+} from 'node:path'
+import {
+  fileURLToPath,
+} from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url))
+
+/*
+ * The rule for a valid skill name is written out in both scripts on purpose, so
+ * that neither skill's script has to import from the other's. This pins the two
+ * copies to one another: changing the rule in one place alone fails here.
+ */
+describe('Skill name pattern', () => {
+  describe('is declared identically by every script that enforces it', () => {
+    const cases = [
+      { scriptPath: '.claude/skills/audit/scripts/audit.js' },
+      { scriptPath: '.claude/skills/flatten/scripts/build.js' },
+    ]
+
+    test.each(cases)('$scriptPath', ({ scriptPath }) => {
+      const content = readFileSync(join(repoRoot, scriptPath), 'utf8')
+
+      expect(content)
+        .toContain('const namePattern = /^h[cbf]-[a-z0-9-]{1,61}$/u')
+    })
+  })
+})


### PR DESCRIPTION
# Why

* Close #9

# How

* Migrates the `flatten` build skill and the `audit` name-check skill from `hora-skills`, with `DOMAIN_PREFIX` narrowed to `{ core: 'hc' }` — this library holds the one domain, and the build aborts on a domain directory it cannot find
* Keeps `namePattern` as `hora-skills` declares it, so a sibling library's skill under `core/` is reported as misplaced rather than as misnamed
* Pins the name rule and the prefix table across the two scripts, under `tests/__tests__/skills/`
* Adds `build:`, `prepack:` and `skill-names:`, so `npm pack` ships a `dist/` built from the current source
* Publishes `dist/`, `docs/` and `lib/` in `files:`, and drops `main:` and `types:`, which pointed at the boilerplate's placeholder entry point
