### PR TITLE
🚧 Retake the module index of `/hoc-jest` to read level 1 off the default export

### DIFF
--- a/kit/skills/core/hoc-jest/SKILL.md
+++ b/kit/skills/core/hoc-jest/SKILL.md
@@ -103,10 +103,11 @@ test()`.
   class name is duplicated in Jest's output, in favor of human explorability.
 - **When the subject is not a class** — a module of exported constants, or a
   data file such as a message catalogue — the index rule still holds, but what
-  sits at each level changes: a module is indexed by its exported names, a data
-  file by its path. **A reconciliation between two collections is the one case
-  where the rule cannot hold**, because neither side is the subject; it is
-  indexed by the relation instead. See
+  sits at each level changes. **A module reads level 1 off whatever it
+  default-exports**, and indexes below that by the kind of export and its name; a
+  data file is indexed by its path. **A reconciliation between two collections is
+  the one case where the rule cannot hold**, because neither side is the subject;
+  it is indexed by the relation instead. See
   [structure.md](./references/structure.md#when-the-subject-is-not-a-class).
 - For details on nesting structure and notation, see
   [structure.md](./references/structure.md#describe-structure) /

--- a/kit/skills/core/hoc-jest/references/naming.md
+++ b/kit/skills/core/hoc-jest/references/naming.md
@@ -38,21 +38,25 @@ describe('should call JSON.stringify with value and replacer', () => {})
 
 ## Notation When the Subject Is Not a Class
 
-The table above covers class members. Two other subjects appear, and each has its
-own level-2 notation
-([structure.md](./structure.md#when-the-subject-is-not-a-class)).
+The table above covers class members. Other subjects appear, and each has its own
+notation ([structure.md](./structure.md#when-the-subject-is-not-a-class)).
 
-| subject | level 1 | level 2 | notation |
+| subject | level 1 | level 2 | level 3 |
 | :-- | :-- | :-- | :-- |
-| module of exported constants | module name | exported name | as the source writes it (`ERROR_CODE_HASH`) |
-| data file, a part asserted | the file's path | the part's key path | as the file writes it (`message.form`) |
-| data file, the whole asserted | the file's path | the reading | a bare lower-case noun phrase (`key set`) |
-| reconciliation of two collections | the relation | a collection | a bare lower-case plural (`core rules`) |
+| module whose default export is a class, a function, a declared `const`, or an import binding still under its source's name | that definition's name | the export's kind | the exported name |
+| module whose default export has no name of its own | a name for what the file is about | the export's kind | the exported name |
+| data file, a part asserted | the file's path | the part's key path | ─ |
+| data file, the whole asserted | the file's path | the reading | ─ |
+| reconciliation of two collections | the relation | a collection | ─ |
 
-The last two rows carry no `#` or `.` by design: the absence is what tells a reading
-of a file, or a collection being reconciled, from a definition on a class. This
-notation governs the `describe()` name only — the governing "Notation of Class
-Members" table covers class members alone and is unchanged by it.
+The export's kind is `default export` or `named export`, written out. **A `default
+export` stops there** — it has no name for level 3. A named export puts its name at
+level 3 as `as <name>`, the name as the source writes it (`as deprecated`).
+
+The data-file and reconciliation rows carry no `#` or `.` by design: the absence is
+what tells a reading of a file, or a collection being reconciled, from a definition on
+a class. This notation governs the `describe()` name only — the governing "Notation of
+Class Members" table covers class members alone and is unchanged by it.
 
 ## Test Case Variables
 

--- a/kit/skills/core/hoc-jest/references/structure.md
+++ b/kit/skills/core/hoc-jest/references/structure.md
@@ -467,6 +467,52 @@ describe('constants-error', () => {
 })
 ```
 
+#### Below level 1 comes the kind of export, then its name
+
+A class's members carry their kind in the name — `#` for an instance member, `.` for a
+static one. **An export has no such sigil, so the kind takes a level of its own.**
+
+| Level 2 | Level 3 |
+| :-- | :-- |
+| `default export` | — (a default export has no name to index) |
+| `named export` | `as <the exported name>`, as the source writes it |
+
+```js
+describe('package entry', () => {
+  describe('default export', () => {
+    describe('when imported', () => {
+      test('should be the core ruleset', () => {
+        // ...
+      })
+    })
+  })
+})
+
+describe('package entry', () => {
+  describe('named export', () => {
+    describe('as deprecated', () => {
+      describe('when imported', () => {
+        test('should be the deprecated ruleset', () => {
+          // ...
+        })
+      })
+    })
+  })
+})
+```
+
+- **The name stays greppable.** Somebody who changes a named export searches for its
+  name and lands on a describe, exactly as they would for a class member. Collapsing
+  the two levels into `named export` alone would lose that the moment a module has two.
+- **`as` is what marks the level as a name.** A class member wears `#` or `.`; a bare
+  `deprecated` sitting under `named export` could be read as a behavior or a member
+  instead. `as deprecated` reads as one phrase with the level above it — *a named
+  export, as `deprecated`* — and the name is still what a search finds.
+- **A default export stops at level 2**, because there is no name to put below it. The
+  levels are not padded to match.
+- The module describe is **repeated per export**, the way the class describe is repeated
+  per member, and for the same reason.
+
 ### A data file is indexed by its path
 
 When the subject is a data file — a message catalogue, a fixture set, a generated

--- a/kit/skills/core/hoc-jest/references/structure.md
+++ b/kit/skills/core/hoc-jest/references/structure.md
@@ -415,12 +415,45 @@ The rule above fixes level 1 to a class name and level 2 to a member name. Some
 tests have neither: a module that exports constants, or a data file such as a
 message catalogue. The index rule still holds — only what is indexed changes.
 
-### A module is indexed by its exported names
+### Level 1 names what the module default-exports
 
-Level 1 = the module name, level 2 = the exported name. The module name is the
-file's basename without its extension, standing for the file the way a class name
-stands for its own. Nothing else changes, because an exported name is as
-greppable as a member name.
+The class rule reads level 1 off the class because **the class is what the file is
+about**. A module is the same question with a different answer, and the answer comes
+from what it default-exports:
+
+| `export default` is | Level 1 |
+| :-- | :-- |
+| A class | The class's name |
+| A function | The function's name |
+| A `const` this file declares | That binding's name |
+| An import binding whose name matches the file it came from | That binding's name |
+| A value with no name of its own | **A name chosen for what the file is about** |
+
+A module with no default export at all falls in the last row too.
+
+- **The first four rows are not the file's basename.** They coincide in practice,
+  because a file is named after what it holds, but the anchor is the definition
+  rather than the filename. Rename the file and the describe does not move.
+- **Borrow the identifier wherever there is one to borrow.** A class, a function
+  and a `const` are all names the source already chose, and a name the source chose
+  is one a reader can search for. The rows differ in what is exported, not in how
+  the level is decided.
+- **An import binding is borrowed only while it still names its source.**
+  `import core from './rules/core.js'` passes something along under the name it
+  already had — the binding and the file agree, so the name was not invented here.
+  `import config from './rules/core.js'` renames on the way in, and that name is
+  this file's private label for somebody else's export: it names nothing a reader
+  can trace, so level 1 falls to the last row.
+- **The last row is a judgement, and that is deliberate.** `export default { ... }`
+  written inline has no identifier at all — `index` or `constants-error` names the
+  file, not the subject. Choose the name a reader would use for what the file is
+  about.
+
+**The judgement is only affordable because the test file mirrors the source path**
+([directory.md](./directory.md#directory-structure)). Somebody who edits the source
+reaches its test through the path, so level 1 is what they read once they arrive,
+not what they search for. A test file named by convention rather than by mirroring
+takes that away, and then neither end can be derived.
 
 ```js
 describe('constants-error', () => {


### PR DESCRIPTION
# Why

* Close #46