### PR TITLE
🛡️ Raise `@humanfs/node` to `0.16.8` and pin it through an override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,25 +736,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest": "^30.4.2"
   },
   "overrides": {
+    "@humanfs/node": "^0.16.8",
     "brace-expansion@5": "^5.0.9",
     "flatted": "^3.4.2"
   }


### PR DESCRIPTION
# Why

* Close #57

# How

Clearing the report needed only the lockfile. `eslint` asks for `@humanfs/node` at `^0.16.6`,
so any fresh resolve today lands on the newest 0.16.x and the advisory is gone without anything
else being written. That was rejected: it leaves the floor recorded in a generated file alone,
where a reader looking for what this package refuses to go below has nowhere to look, and where
a regenerated lockfile is the only thing standing between the tree and the vulnerable version.

The override says it in `package.json` instead, beside the two that are already there for
`brace-expansion@5` and `flatted`. `@openreachtech/hora-skills-ort-support` carries the same
line, so the four packages state the same floor rather than each holding its own resolved
version.

There is no third commit for the lockfile, which is what the sibling package's history shows
for its two overrides. `npm install` after the override wrote nothing: a lockfile records the
resolved version and never the override that produced it, and the resolved version was already
`0.16.8`.
