### PR TITLE
💪 Take dependencies out of `chore` into a `deps` type in `/hoc-git-commit`

### DIFF
--- a/kit/skills/hoc-git-commit/SKILL.md
+++ b/kit/skills/hoc-git-commit/SKILL.md
@@ -46,9 +46,10 @@ Resolve which one applies, in this order.
    git log --no-merges -n 30 --pretty=format:'%s'
    ```
 
-   If **most** of them begin with `feat:` / `fix:` / `refactor:` / `test:` / `docs:` /
-   `chore:` (optionally with a scope, as in `feat(resolver):`), the project uses
-   conventional. Otherwise it uses imperative.
+   If **most** of them begin with a lowercase word and a colon — `feat:` / `fix:` /
+   `refactor:` / `docs:` and the rest, optionally with a scope, as in `feat(resolver):` — the
+   project uses conventional. Otherwise it uses imperative. The types themselves are listed in
+   the conventional format file; read the ones named here as examples, not as the whole set.
 
 3. **Default to imperative** when the history is too short to judge, as in a new repository.
 

--- a/kit/skills/hoc-git-commit/references/format-conventional.md
+++ b/kit/skills/hoc-git-commit/references/format-conventional.md
@@ -43,7 +43,8 @@ feat(resolver): add unlockClientMemberSignIn mutation
 | `refactor` | restructuring with no change in behavior |
 | `test` | tests added or changed, with no production-code change |
 | `docs` | documentation only |
-| `chore` | build config, dependencies, tooling |
+| `chore` | build config, tooling |
+| `deps` | a dependency the project takes on, gives up, or moves to another version |
 | `style` | formatting only, no code meaning changed |
 | `perf` | a change made for performance |
 
@@ -58,6 +59,16 @@ feat(resolver): add unlockClientMemberSignIn mutation
   — and the two should have been separate commits in the first place. See the granularity
   detail file.
 - When two types would both fit, the commit is doing two things. Split it.
+- **`deps` covers the lock file too.** Installing, uninstalling and moving a version all take
+  it, and so does the `package-lock.json` regenerated with them. A lock file records how the
+  dependency tree resolved; it is not tooling config, and one operation split across two types
+  breaks the thread for whoever reads the history back.
+- To pick out only the packages added — for release notes, say — filter on **the verb**, not
+  the type: `deps: install`, `deps: uninstall`. How the history gets displayed is not a reason
+  to cut the type layer finer.
+- **The internal-parts rule above does not reach dependencies.** It is about the repository's
+  own work: a class only `Alpha` uses is part of what `Alpha` delivers, and an installed
+  package never is. A package installed to build `Alpha` is `deps`, not `feat`.
 
 ## Summary
 


### PR DESCRIPTION
# Why

* Close #68

# How

**The type table is the layer that moved, and the verb table is the reason it was the right one.**
`Install` / `Uninstall` already had a row of their own, naming the dependency rather than
`package.json`, so the vocabulary was already treating a dependency as its own kind of event.
Only the coarse layer above it still read a package as an errand. Nothing in the verb table
needed touching.

**`deps`, not `install`.** Naming the type after the operation was the obvious alternative and it
was rejected twice over: a type is a classification and a verb is an operation, so
`install: uninstall date-fns` collapses the two, and the word would collide with the rows that
already exist. `deps` also arrives with currency — Dependabot and Renovate write `chore(deps)` —
so the reader meets a familiar word even though this repository raises it from a scope to a type.

**`chore` was narrowed in the same edit rather than left alone.** A row still reading
"dependencies" beside a `deps` row gives one operation two homes, and a type table that admits
two right answers has stopped classifying anything.

**Release-note filtering was answered with the verb, not with more types.** Picking out only the
packages added is `deps: install` / `deps: uninstall`; how a history gets displayed is not a
reason to cut the type layer finer, and saying so in the skill stops the question coming back as
a `deps-add` proposal.

**The detection rewrite is a second commit because it is a second decision.** Adding `deps` was
what exposed the enumeration of six type names in `SKILL.md` as a copy of the table, but the type
stands on its own and is reviewable on its own. The rewrite then took the shape-based form — a
lowercase word and a colon — because that is what the detection actually rests on; the names left
in it are examples, and the type table is named explicitly as the one place holding the set.
Cutting the list silently would have read as a narrower rule rather than a broader one.

**The two commits come from `hora-skills`, which is archived.** The change was made there against
`hc-git-commit`, this skill's predecessor, and is carried here because this repository is where
the convention continues. The surrounding text has since diverged — the branch convention lives
in `/hoc-git-branch` now — but not at either of the two sites, so both patches applied unchanged
apart from the path. Nothing goes back the other way.

# Note

* **A repository that lints commits with `@commitlint/config-conventional` will reject `deps:`.**
  Its `type-enum` carries `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
  `revert`, `style` and `test`, and nothing here extends it. A project adopting the convention
  under that linter has to add the type to its own config.