### PR TITLE
💪 Add the merge-and-rebase cycle and the `-r` prohibition to `/hoc-git-branch`

### DIFF
--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -276,6 +276,27 @@ Merge the core/ rename in the repository documents
     git branch -d dev
     git switch -C dev origin/main
     ```
-- **When two branches were cut from the same commit on a trunk, whichever merges second rebases
-  onto the trunk's new tip first.** The second branch then merges into the trunk as it now
-  stands, rather than reopening a line that was already closed.
+- **Merging several sub-branches back is a cycle, not a batch: merge one, rebase the next onto
+  the trunk's new tip, merge it, rebase the one after that.** Every merge moves the tip, so each
+  branch is rebased against a commit that did not exist while the branch before it was still
+  open. Each then merges into the trunk as it now stands, rather than reopening a line that was
+  already closed.
+
+  ```bash
+  git switch <trunk>
+  git merge --no-ff <first> -m 'Merge …'
+
+  git rebase -r <trunk> <second>        # onto the tip the merge above just made
+  git switch <trunk>
+  git merge --no-ff <second> -m 'Merge …'
+
+  git rebase -r <trunk> <third>         # onto the tip that merge made
+  git switch <trunk>
+  git merge --no-ff <third> -m 'Merge …'
+  ```
+
+  - **The rebases cannot be done in advance.** Aiming them all at one point — the commit the
+    branches were cut from, or anywhere else — settles nothing past the first merge: the second
+    branch is behind the tip again by the time its turn comes. The commit each rebase needs does
+    not exist until the merge before it is made.
+  - **Two branches are the smallest case of this, not a rule of their own.**

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -264,6 +264,18 @@ Merge the core/ rename in the repository documents
 - **Always `--no-ff`, never fast-forward.** A fast-forward leaves no commit a human can point
   at: the branch's commits are strung onto the trunk's line, and the fact that they arrived
   together, as one piece of work, stops being visible at all.
+- **Before each merge, confirm the branch is fast-forwardable.** `--no-ff` is only doing its
+  work when a fast-forward is what would otherwise have happened. On a branch that has fallen
+  behind the tip, git makes a three-way merge regardless, and the flag changes nothing.
+
+  ```bash
+  git merge-base --is-ancestor <trunk> <branch>   # must succeed
+  ```
+
+  Failure means the branch has not been rebased onto the current tip. Rebase it, then merge.
+  - **A merge commit's two parents are not evidence that `--no-ff` did anything.** A three-way
+    merge has two parents as well, and nothing in the finished history separates the two. That
+    is why this is checked before the merge, and cannot be checked after it.
 - **Delete the branch once it is merged.** Its name was written for whoever watched the work in
   flight, and that reader is gone. This includes a trunk that merges into another trunk —
   `dev` and `env` are deleted once they land on `main`.

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-git-branch
-description: "Conventions for the branches a repository carries: which branch is a trunk and what that role obliges, how a general branch is named, the empty marker that opens a trunk, and the `--no-ff` merge that closes a sub-branch along with the subject that merge commit carries. What goes inside a commit, and how a subject is worded generally, belong to the git commit convention. Use before cutting a branch, before merging one back, and before deciding whether work needs a branch structure at all."
+description: "Conventions for the branches a repository carries: which branch is a trunk and what that role obliges, how a general branch is named, the empty marker that opens a trunk, and the `--no-ff` merge that closes a sub-branch along with the subject that merge commit carries. What goes inside a commit, and how a subject is worded generally, belong to the git commit convention. Use before cutting a branch, before merging one back, and before deciding whether work needs a branch structure at all. Every `git rebase` in this scheme takes `-r`."
 ---
 
 # Git Branch

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -108,6 +108,14 @@ So the order is: commit in a meaningful sequence until the work is ready for rev
 together whatever turns out to be one decision after all, and only then cut the markers and
 split the line into sub-branches.
 
+- **Every sub-branch is cut from the trunk, never from the sub-branch before it.** Splitting a
+  finished line means returning to the trunk for each cut, not walking forward along the line as
+  the branches come off it. A branch cut while standing on the previous sub-branch carries that
+  branch's commits as well as its own, and the two arrive at the trunk stacked instead of side by
+  side — the second merge then reopens a line the first one closed.
+  - **What `git branch` shows afterwards looks the same either way.** Only the commit each branch
+    was created from tells the two apart, and by the time the merges expose it the structure is
+    already built.
 - **This holds only while the commits are unshared.** Folding and splitting both rewrite
   history. Once the work has been pushed, the line stands as it is, and a structure it did not
   get is a structure it does not get.

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -12,6 +12,34 @@ What belongs in a single commit, and how a subject is worded, are settled by the
 convention. The two commits described here are the exception it points at: their subjects are
 specified in full below, because what they say is inseparable from what they are for.
 
+## Every rebase takes `-r`
+
+**`git rebase` without `-r` (`--rebase-merges`) is forbidden. There is no ordinary case that
+omits it.** Not preferred, not recommended where a branch has merges in it: the flag goes on
+every invocation, and a command written without it is wrong whether or not this particular
+branch happens to survive the omission.
+
+```bash
+git rebase -r <trunk> <branch>
+git rebase -r --onto <trunk's new tip> <the commit this branch was cut from> <branch>
+```
+
+Without `-r`, `git rebase` drops every merge commit it replays. A branch that carried its own
+sub-branches arrives flattened, and the `--no-ff` merges inside it are gone — the exact thing
+`--no-ff` was used to keep. The loss is silent: the rebase reports success, the working tree
+matches, and what is missing is structure no diff reports.
+
+**Whether the branch holds a merge commit right now is not the test.** A branch with none loses
+nothing today, but deciding case by case means re-examining the question at every rebase and
+getting it wrong on the one branch that did carry a merge. The flag costs nothing when there is
+nothing to preserve.
+
+- The single thing that lifts it is a deliberate decision to flatten a branch's internal merges,
+  taken as such and said out loud. Nobody arrives there by default.
+
+This rule stands ahead of everything below because the commands that need it appear throughout,
+and because a rebase that drops a merge cannot be spotted afterwards from the result.
+
 ## The trunk branch
 
 A **trunk branch** is one that other branches are cut from and merged back into.
@@ -243,12 +271,3 @@ Merge the core/ rename in the repository documents
 - **When two branches were cut from the same commit on a trunk, whichever merges second rebases
   onto the trunk's new tip first.** The second branch then merges into the trunk as it now
   stands, rather than reopening a line that was already closed.
-- **Every rebase in this scheme uses `-r` (`--rebase-merges`).**
-
-  ```bash
-  git rebase -r --onto <trunk's new tip> <the commit this branch was cut from> <branch>
-  ```
-
-  Without `-r`, `git rebase` drops every merge commit it replays. A branch that carried its own
-  sub-branches then arrives flattened, and the `--no-ff` merges inside it are gone — the exact
-  thing `--no-ff` was used to keep.


### PR DESCRIPTION
# Why

* Close #78

# How

* **The `-r` rule was moved to the head of the document rather than restated where it is needed.**
  The commands that take the flag are spread across three sections, so a rule placed beside any
  one of them is a rule the other two readers walk past. The cycle's example commands carry the
  flag inline as well, so the path that gets copied already has it.
* **Its wording became a prohibition rather than a firmer recommendation.** The old line named the
  flag's purpose — preserving merge commits — which invites deciding per branch whether there is a
  merge to preserve. Taking the judgement away takes the wrong judgement with it, and the flag
  costs nothing on a branch with nothing to keep.
* **The two-branch rebase rule was replaced, not extended.** The batch reading it invites is the
  failure itself, so a caveat added underneath would have left the misreading standing. What is
  there now states the cycle first, and gives the commands for three branches.
* **The fast-forward check is placed before the merge because it has no form that works after
  one.** A three-way merge commit and a `--no-ff` merge commit are the same shape, so nothing
  inspected later separates them.
* **The cutting rule went to `When the structure is decided`, not to the merge section.** Where a
  branch starts is settled when the line is split; the merge is where the consequence surfaces
  rather than where the decision is made.
* **Five commits, one rule each**, so a rule that turns out wrong can be reverted without taking
  the others with it.

# Note

* **The frontmatter `description` changed.** It is what the skill listing shows, so the `-r` rule
  reaches a reader who has not opened the file — and it is what consuming repositories re-read at
  the next sync.
* `dist/` is a build artefact outside git. Consuming repositories pick the rules up at the next
  `npm run build`.
* **Nothing was added telling the reader when to open the document.** The `description` already
  says it, and a document instructing its own reader to read it closes no gap.
