### PR TITLE
🛡️ Clear the `js-yaml` advisory across both major lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4358,9 +4358,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
   "overrides": {
     "@humanfs/node": "^0.16.8",
     "brace-expansion@5": "^5.0.9",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "js-yaml@3": "^3.15.2",
+    "js-yaml@4": "^4.3.2"
   },
   "allowScripts": {
     "fsevents": false,


### PR DESCRIPTION
# Why

* Close #88

# How

## Two keys, one per major line

The advisory covers `3.0.0 - 3.15.1 || 4.0.0 - 4.3.1`, and both lines are installed because
`eslint` and the `jest` chain asked for different ranges. A single `js-yaml` key would move both
onto one line, so each line takes a key scoped to its own major and moves to the fix published
there.

```json
  "js-yaml@3": "^3.15.2",
  "js-yaml@4": "^4.3.2"
```

Both are patches within their line — `3.15.1` → `3.15.2` and `4.3.1` → `4.3.2` — and neither
`eslint` nor `jest` moves.

## The override, not `npm audit fix`

`js-yaml` is a package this project never asked for on either line, so there is no declared range
here to raise, and the fix the audit offers decides for both lines at once while reaching the
direct dependencies to do it. An override raises the transitive alone and leaves each direct
dependency's version a decision of its own.

## Two commits, the lockfile last

The keys go in first, then the lockfile after a single install. The lockfile records one
resolution rather than a sum of parts, so it is committed once, at the end, with its subject
naming the command that produced it.

# Note

* **Both fix versions clear the quarantine**, published on 2026-08-26 against a
  `min-release-age` of 7 days, so nothing is bypassed.
* The two keys join three overrides already in `package.json`, every one of which was written to
  clear an audit report.
