### PR TITLE
💪 Add the rules settled in `0.4.0` to eleven existing skills

### DIFF
--- a/kit/skills/hoc-coding-styles/SKILL.md
+++ b/kit/skills/hoc-coding-styles/SKILL.md
@@ -64,6 +64,9 @@ if (
 - When writing a method chain, allow at most one receiver per line, and at most one method per line.
 - `this` does not count as a receiver.
 - Unless instructed to chop down, place the first method of a method chain on the same line as the receiver.
+- **Counting receivers and methods does not settle a chain on its own.** The count of complex
+  expressions on the line governs it too, and a chain can pass this rule while failing that one.
+  Read both before deciding where a chain breaks.
 
 ```javascript
 // NG
@@ -82,6 +85,51 @@ const ids = this.extractSamples()
   .filter(it => it)
   .map(it => it.id)
 ```
+
+### Where the chain itself carries the complex expressions, chop it
+
+**A receiver derived by a call, or reached through a computed key, is a complex expression of
+its own** — and the method called on it is a second. One receiver and one method sit within
+the count this section states, so this rule permits the line; the rule against two complex
+expressions on one line is what forbids it.
+
+**The fix there is to chop the chain, not to name a variable.** Chopping already secures the
+readability the naming would have bought, and introducing a variable for what a line break
+handles is what the rule against meaningless assignments turns away.
+
+```javascript
+// NG: two calls on one line — the key's, and the method's
+return entity[resolveKey(this.ModelCtor.name)].toSorted(this.getSorter())
+
+// NG: a variable that chopping made unnecessary
+const key = resolveKey(this.ModelCtor.name)
+
+return entity[key]
+  .toSorted(this.getSorter())
+
+// OK: the chain carries them, so the chain is where it breaks
+return entity[resolveKey(this.ModelCtor.name)]
+  .toSorted(this.getSorter())
+```
+
+### One-line and chopped chains stand together
+
+**A file holding both is not inconsistent for holding both.** Every line is decided by what it
+carries, so two chains of the same length break differently the moment one of them derives its
+receiver and the other does not.
+
+```javascript
+// One line: the receiver is a plain identifier, and the method is the only call
+const sorted = array.toSorted(sorter)
+
+// Two lines: the receiver is a call, so the method is the second one on the line
+const [latest] = this.extractStatuses()
+  .toSorted(comparer)
+```
+
+Reading the shorter one as a breach of the longer one's shape is the mistake this note exists
+to prevent. Where the two differ, look for what the receiver costs before calling it a
+divergence.
 
 ## Write one property per line in a property chain
 

--- a/kit/skills/hoc-documentation/SKILL.md
+++ b/kit/skills/hoc-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-documentation
-description: "Documentation writing conventions. Referenced when updating or writing READMEs, design documents, comments, etc. Defines the language a document generated for a reader is written in, and the notation used when referring to class members, among other things."
+description: "Documentation writing conventions. Referenced when updating or writing READMEs, design documents, comments, etc. Defines what a document may state as fact and what it must reach for instead, the language a document generated for a reader is written in, and the notation used when referring to class members, among other things."
 ---
 
 # Documentation
@@ -9,6 +9,36 @@ This gathers the conventions for writing documentation (READMEs, design document
 
 - When writing or updating documentation, follow the conventions in this skill.
 - Follow this skill when writing or updating `SKILL.md` as well (referenced from the skill-updating convention).
+
+## A document states only what it can check
+
+**A fact a document cannot verify is a copy, and a copy rots.** Where the fact lives somewhere
+else, the document holds a second record of it, and nothing tells a second record when the first
+one moves.
+
+Measured across four sibling packages, each carrying the same four-row table of what the others
+hold: sixteen claims, five of them wrong. **Every wrong one was a row about a package other than
+the one whose document it sat in.** The row each document made about itself was derivable from
+the repository holding it, and not one of those had drifted.
+
+- **Annotating the rot does not stop it.** The convention covering that table already said, in
+  plain words, that those rows go stale and that no check it ran could catch them. The note stood
+  while the rows were wrong: being right about the decay arrested none of it.
+- **The remedy is removing the restatement, never maintaining it.** What replaced the copied
+  column was a link to each package's own list. The fact did not disappear — it stopped being
+  written down twice and became something the reader reaches instead.
+- **A check makes a restatement correct and still does not make it worth keeping.** The places a
+  repository-local audit gated never went wrong, and they were removed along with the rest. The
+  check existed only because the document was holding a copy, so deleting the copy deleted the
+  machinery with it.
+
+**The test is not whether the fact is true today.** It is whether the repository holding the
+document owns the fact. Where it does not, write what the reader can follow to the source; where
+it does, ask whether the document needs to say it at all.
+
+This is the same instinct as naming one governing source for a rule, turned on facts. **A rule
+restated elsewhere is aligned to its source; a fact restated elsewhere is deleted in favour of
+reaching it.**
 
 ## Notation of Class Members
 

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -177,6 +177,29 @@ What the finished line is looked at for:
   - Deciding on size alone splits a pair that should have been one branch, because size is the
     test that a pair of one-commit steps passes and a pair of large steps fails.
 
+### The order the sub-branches merge in
+
+**Merge the cheap ones first and the substantial ones last.** Where one sub-branch changes a line
+of configuration and another changes the code behind it, the line of configuration goes in first
+and the code last.
+
+**The reason is how a diff is read.** A reader starts at the newest commit and works down, so
+whatever sits on top is what they see first and read hardest. Put a one-line change there and the
+substantial one is buried beneath it; put the substantial one there and the small changes sit
+where they cost nothing, at the bottom, passed over on the way.
+
+- **This is not an argument about risk.** Ordering by cost so that the cheap gains survive if the
+  expensive work is rejected reaches the same order by another route, and it is not the reason.
+- **A change that only becomes possible once the others land goes last, whatever it costs.** Where
+  several sub-branches each clear the way for one change to a file they share, that change is not
+  spread across them: it gathers into a sub-branch of its own, placed after them. A relaxation
+  removed only once every file it named has been fixed is the ordinary shape of this.
+- **Do not reorder the merges to dodge a rename.** A rebase carries a commit onto a file its base
+  renamed underneath it. Measured on a branch whose base had renamed a file the branch edits: the
+  edit landed on the new name, every merge the branch held survived, and the tree came out
+  differing only by what the new base added. A conflict predicted there is not a reason to put a
+  branch anywhere but where its size says.
+
 ### The same work across sibling repositories takes the same order
 
 Where one piece of work lands in two repositories at once, the sub-branches under each trunk

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-git-branch
-description: "Conventions for the branches a repository carries: which branch is a trunk and what that role obliges, how a general branch is named, the empty marker that opens a trunk, and the `--no-ff` merge that closes a sub-branch along with the subject that merge commit carries. What goes inside a commit, and how a subject is worded generally, belong to the git commit convention. Use before cutting a branch, before merging one back, and before deciding whether work needs a branch structure at all. Every `git rebase` in this scheme takes `-r`."
+description: "Conventions for the branches a repository carries: which branch is a trunk and what that role obliges, how a general branch is named, and how work is split off a trunk and merged back with `--no-ff`. Use before cutting a branch, before merging one back, and before deciding whether work needs a branch structure at all. What goes inside a commit, and how a subject is worded, belong to the git commit convention. Every `git rebase` here takes `-r`."
 ---
 
 # Git Branch

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -138,6 +138,12 @@ split the line into sub-branches.
   - **What `git branch` shows afterwards looks the same either way.** Only the commit each branch
     was created from tells the two apart, and by the time the merges expose it the structure is
     already built.
+  - **The exception is a branch that cannot stand up without another one's work**, where that
+    other reaches the trunk by its own pull request rather than by the local merge described
+    below. Sitting on it is how the prerequisite is had, and the reason the rule gives — a second
+    merge reopening a line the first one closed — does not reach the case, because the two never
+    merge into the trunk together. When the prerequisite lands, rebase the stack onto the trunk's
+    new tip and carry on.
 - **This holds only while the commits are unshared.** Folding and splitting both rewrite
   history. Once the work has been pushed, the line stands as it is, and a structure it did not
   get is a structure it does not get.

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -375,4 +375,29 @@ Merge the core/ rename in the repository documents
     branches were cut from, or anywhere else — settles nothing past the first merge: the second
     branch is behind the tip again by the time its turn comes. The commit each rebase needs does
     not exist until the merge before it is made.
+  - **After each rebase and before its merge, confirm the branch still carries something.** A
+    rebase drops a commit whose change the trunk already holds, and where that was the branch's
+    only commit the branch arrives at the trunk's own tip. The `--no-ff` merge that follows then
+    prints `Already up to date.`, exits zero, creates nothing, and **a rung of the structure is
+    gone** — leaving a graph that reads as one which was never meant to have it.
+
+    ```bash
+    git rebase -r <trunk> <branch>
+    git rev-list --count <trunk>..<branch>   # must be greater than zero
+    ```
+
+    **Measured before it and after it is not the same measurement.** Before the rebase the count
+    was one and would have passed; the rebase took it to zero. The only warning git gave was a
+    hint about skipped cherry-picks, which `-q` and a trailing `tail` both remove.
+
+    - **This is not the ancestry check above, and neither catches what the other does.** A
+      branch left behind the tip fails `--is-ancestor` and still makes a merge commit, because
+      it holds commits of its own. A branch sitting exactly on the tip **passes**
+      `--is-ancestor` — it is not behind anything — and makes none.
+    - **A count of zero is not answered by skipping the merge.** The change is in the trunk
+      already, so the structure was drawn with one rung too many, or the change belongs to a
+      different sub-branch than the one that carried it. Both are decisions, not repairs.
+    - The same emptiness arrives by accident wherever a step meant to fill the branch reported
+      success without committing — a `cherry-pick` refused for a bad flag, a patch that did not
+      apply, a copied file identical to the one already there. The check does not care which.
   - **Two branches are the smallest case of this, not a rule of their own.**

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -40,6 +40,28 @@ nothing to preserve.
 This rule stands ahead of everything below because the commands that need it appear throughout,
 and because a rebase that drops a merge cannot be spotted afterwards from the result.
 
+### Editing a commit inside the branch takes `-i` as well
+
+**`-r` keeps the merges; `-i` is what opens the todo list.** Given `-r` alone, a rebase runs the
+sequencer but never presents a todo, so a sequence editor named in the environment is never
+called — and the run reports every step successful while handing each commit back with the hash
+it went in with.
+
+```bash
+git rebase -i -r --onto <base> <the commit the branch was cut from> <branch>
+```
+
+Measured on a branch carrying one merge: with `-r` alone the rebase printed eight steps and
+`Successfully rebased`, and no hash changed. With `-i -r` the reword applied and the merge commit
+survived, the graph keeping its shape.
+
+- **Being unable to answer a prompt is not a reason to avoid `-i`.** Point the sequence editor
+  and the message editor at scripts — one rewrites the todo, the other rewrites the message —
+  and nothing prompts. An interactive rebase can be driven rather than attended.
+- **Rebuilding the sub-branch by hand is the fallback for a conflict, not for a reword.**
+  Cherry-picking its commits onto a fresh branch and amending the one that needed the new
+  subject reaches the same tree at the cost of the branch and every merge above it.
+
 ## The trunk branch
 
 A **trunk branch** is one that other branches are cut from and merged back into.

--- a/kit/skills/hoc-git-branch/SKILL.md
+++ b/kit/skills/hoc-git-branch/SKILL.md
@@ -163,6 +163,19 @@ What the finished line is looked at for:
 - **One sub-branch with something to group is enough.** The others may carry a single commit
   each; what makes the trunk worth having is that at least one merge names a piece of work
   assembled from parts.
+- **A sub-branch of its own is decided twice over: by what the piece carries, and by whether it
+  stands beside the others as work in its own right.** The bullets above settle the first. The
+  second asks whether the pieces are siblings — each a thing that was done, reviewable on its own
+  merit — or steps toward one thing they share. **Steps of one piece go in one sub-branch,
+  however much each carries.**
+  - Two classes reshaped, each for reasons of its own, are siblings: either could be taken and
+    the other left. A fix to the code and the removal of the relaxation that fix made unnecessary
+    are not — the second exists only because the first happened.
+  - **Looking like siblings is not being siblings.** Two methods rewritten, in two files, in two
+    classes, read as a pair of independent jobs. If neither of them alone clears the thing the
+    work set out to clear, they are halves of one job and belong on one branch.
+  - Deciding on size alone splits a pair that should have been one branch, because size is the
+    test that a pair of one-commit steps passes and a pair of large steps fails.
 
 ### The same work across sibling repositories takes the same order
 

--- a/kit/skills/hoc-git-commit/SKILL.md
+++ b/kit/skills/hoc-git-commit/SKILL.md
@@ -324,9 +324,10 @@ substitutes for it. Where nothing listed names it, open the subject with the ver
   there, and which of `install`, `update` or `audit fix` resolved them is not. Naming the
   version or the packages instead would restate what the commit before it already said, and
   lose the operation.
-  - **This is the second of the two commits a dependency change makes**, the project's own
-    version bump included. The first moves `package.json` and names the decision — `Install
-    date-fns 4.1.0`, `Update the package version to 0.8.0 in package.json`. The second moves
+  - **This is the second of the two commits that moving a version makes**, and the shape is the
+    same whether the version moved is a dependency's or the project's own. The first moves
+    `package.json` and names the decision — `Install date-fns 4.1.0` for a dependency, `Update
+    the package version to 0.8.0 in package.json` for the project's own bump. The second moves
     the lock file and names the command that regenerated it. Neither stands in for the other,
     and folding them together would hide which of the two a later revert has to undo.
 - **A subject describes a transition, never a state.** `Don't disable the action button when

--- a/kit/skills/hoc-git-commit/references/granularity.md
+++ b/kit/skills/hoc-git-commit/references/granularity.md
@@ -90,7 +90,7 @@ generated artifact, an initial scaffold. What makes them legitimate is that they
 | Refactor and behavior change | A refactor is reviewed by confirming behavior did **not** change. Mixed together, the reviewer cannot tell which lines were meant to alter behavior. |
 | Mechanical rename and logic edit | A rename is verified by scanning that it is uniform. One hand-edited line hidden among 200 renamed ones is invisible. |
 | Formatting or lint fixes and substance | Whitespace churn buries the two lines that matter. |
-| Dependency bumps and code that uses them | The bump is a separate risk with a separate rollback. |
+| Dependency raises and code that uses them | The raise is a separate risk with a separate rollback. |
 | Generated artifacts (`package-lock.json`, generated types) and hand-written source | Generated diffs are large and unreviewable; keeping them separate keeps the source commit readable. |
 | Unrelated files that happen to be dirty | They are unrelated. This is the most common cause of an accidental umbrella commit. |
 

--- a/kit/skills/hoc-git-commit/references/granularity.md
+++ b/kit/skills/hoc-git-commit/references/granularity.md
@@ -128,6 +128,12 @@ reviewed. This is test-driven development written into the history rather than i
     then the thing itself. Each step deletes something nothing else points at any more, so no
     intermediate state refers to what is gone. Going the other way breaks at the first commit,
     which is what makes a removal look unsplittable when it is not.
+    - **A member's own tests are the exception, and they come out last.** The rule turns on
+      references that must not dangle, and a test's reference to what is gone does not break the
+      tree — it reports. Removing the implementation first is what makes it report: the suite
+      goes red, and the commit taking the tests out is the one that clears it again. Taken the
+      other way every step is green, so nothing distinguishes removing the right tests from
+      removing the wrong ones. What that proves, and where it fails hardest, is `hoc-jest`'s.
   - Retiring a check that a CI workflow runs, an npm script registers, and a script file
     implements is three commits, and taken in this order not one of them leaves a dangling
     reference behind:

--- a/kit/skills/hoc-git-commit/references/granularity.md
+++ b/kit/skills/hoc-git-commit/references/granularity.md
@@ -193,6 +193,23 @@ The first commit is one line of a `.gitignore`, and it leads because it is the o
 changes what an existing entry matches. The two `Add` commits fill sections the two structural
 commits put there, and they wait until both are in place.
 
+**A test and the implementation it covers are not ordered by this sequence.** The implementation
+is the behavior change, so the sequence would lead with it, and the rule that a class's tests are
+committed before its implementation says otherwise. That rule governs the pair; the sequence
+orders whatever else the line holds.
+
+So work that also brings the existing tests up to convention lands in three commits, with the
+behavior change last of the three:
+
+```
+Tidy up the existing test for <the class>    structure
+Update the test for <the class>              addition
+Update <the class>                           behavior
+```
+
+The middle commit is red where it sits, and that is what it is for — the claim stands there on
+its own, and the commit after it is the one that makes the claim true.
+
 **Coherence bounds the sequence.** Where this order would leave a commit referring to what is
 not there yet, the seam is what is wrong, not the order — find the seam first, and sequence
 what comes out of it.

--- a/kit/skills/hoc-git-commit/references/granularity.md
+++ b/kit/skills/hoc-git-commit/references/granularity.md
@@ -251,6 +251,14 @@ git diff              # confirm what is being left for the next commit
     - **The premise is what buys the freedom, so the premise has to hold.** A commit still
       there when the work is shared was never one of these, whatever was intended when it was
       made. Delete it before the branch goes out, or write it as any other commit.
+- **A change the same work is about to take away.** A commit that writes something a later
+  commit in the same line removes has recorded a state nobody will ever want, and whoever
+  bisects through it is reading a decision that was never taken. **The check is mechanical: for
+  each commit, ask whether its diff is still there at the tip.** In one measured case a commit
+  had rewritten a block of configuration that a commit two further on deleted outright — not one
+  line of what it wrote survived, and the whole of it was churn.
+  - The fix is to cut the line again, not to add a commit that corrects it. That is available
+    only while the commits are unshared, which the git branch convention bounds.
 - **End-of-day dumps.** A single commit holding everything touched since morning is the
   default outcome of never deciding granularity. Decide it while working.
 - **Typo-fix follow-ups on unpushed work.** A `Fix typo` commit immediately after the commit

--- a/kit/skills/hoc-jest/SKILL.md
+++ b/kit/skills/hoc-jest/SKILL.md
@@ -49,6 +49,24 @@ guarantee is not the implementation's internal circumstances, but the member's
   branch, or variable element, the justification must be "this input/state
   cannot exist under the contract," never "because I know the implementation."
 
+### Run the test against the unchanged code first
+
+**A test written for a change is run against the code as it stands, before the
+change, and it has to fail there.** A test that passes against the unchanged
+code is describing what the code already does — the one thing a test must not
+be, and the shape a test takes when it is written by reading the very
+implementation it is meant to check.
+
+Measured on one such run: the new cases failed 19 and passed 8 against the
+unchanged code, and all 27 passed once the code had changed.
+
+- **The cases that pass against the unchanged code are the ones covering
+  behaviour the change does not touch**, and that is correct rather than a
+  defect. In the run above the 8 were the surface that already existed, whose
+  signature and behaviour the change left alone.
+- So the run reports a split as well as a verdict: which of the new cases cover
+  new ground, and which are holding ground that was already held.
+
 ## Core principle: don't put logic in test files
 
 A test must consist **only of assertions** (`expect()`) that **check simple

--- a/kit/skills/hoc-jest/SKILL.md
+++ b/kit/skills/hoc-jest/SKILL.md
@@ -144,6 +144,28 @@ codebase.
 - Comments inside **this skill's own examples** (` ```js ``` ` blocks) follow the
   same rule, since they illustrate the very code the rule governs.
 
+## Removing a member takes two commits, implementation first
+
+**When a member or a class is removed, the implementation goes out first and
+the tests that covered it go out second.** Two commits, in that order.
+
+The order is what produces the evidence. The first commit leaves the suite
+failing, the second leaves it passing again, and that pairing is the only thing
+showing that the tests removed were the tests covering what was removed.
+
+- **In this order the red persists until the correct tests come out.** Remove
+  the wrong ones and the suite is still failing, because the tests for the
+  member just deleted are still sitting there. That is the check doing its
+  work.
+- **The reverse order is green at every step**, because a suite with fewer
+  tests still passes. Removing tests first and the member second reports
+  nothing at either commit, whether or not the right tests were taken.
+- **It is silent exactly where it matters most.** Take a member that never had
+  tests of its own. Remove tests first, take another member's by mistake, then
+  remove the member: both commits pass, the other member is now uncovered, and
+  nothing anywhere said so. There was no red to go missing, because there was
+  never a test to turn red.
+
 ## Detail files
 
 - [directory.md](./references/directory.md) — directory layout, import paths

--- a/kit/skills/hoc-jest/references/prohibit.md
+++ b/kit/skills/hoc-jest/references/prohibit.md
@@ -84,6 +84,22 @@ expect(core.rules)
 - **Never let it stand as the whole assertion.** Pinning the type is half the check; the
   concrete value is pinned by the assertion next to it. Alone, it is a loose matcher again.
 
+#### Where the value is made at the moment of the call
+
+**That last rule has one case it does not reach: a value produced when the call happens.** A
+clock read, a random draw — there is no concrete value to pin beside the type, because none
+exists until the call is made, and none is the same twice.
+
+There `expect.any(<concrete type>)` stands as the whole assertion, and it is not a loosening.
+`expect.any(Date)` on a default a factory fills from the clock still excludes every wrong value
+the assertion could otherwise have let through — a string, a number, an argument that never
+arrived.
+
+- The alternative offered above — binding the first return value to `expected` and comparing by
+  identity — reaches a memoized value, which is handed back to the caller. It does not reach a
+  value that goes **into** a call and is never returned, which is where a filled-in default is
+  observed.
+
 ## Do Not Write `jest.fn()` Directly Inline Inside `test()`
 
 Creating and using a `jest.fn()` inside `test()` (injecting it into args,

--- a/kit/skills/hoc-npm-install-scripts/SKILL.md
+++ b/kit/skills/hoc-npm-install-scripts/SKILL.md
@@ -119,6 +119,14 @@ printed.
 - Installing once, after the settings are complete, is the same shape as concentrating the
   install into a single run at the end of a release.
 
+## Write `allowScripts` with the install-scripts command, never with `npm pkg`
+
+`approve` and `deny` edit `package.json` in place and leave the rest of it alone. **`npm pkg
+set` and `npm pkg delete` do not: they silently drop the dependency fields that are empty**, so
+one line added to `allowScripts` arrives as a diff that also deletes lines nobody asked it to.
+
+- `overrides` has no subcommand of its own, so it is edited by hand for the same reason.
+
 ## The npm configuration file is written `key = value`
 
 Spaces on both sides of the `=`.

--- a/kit/skills/hoc-npm-install-scripts/SKILL.md
+++ b/kit/skills/hoc-npm-install-scripts/SKILL.md
@@ -70,6 +70,15 @@ specifically failed. Whoever reads the commit should not have to derive it again
 - Where projects are generated from a boilerplate, the denials common to all of them belong
   in the boilerplate's own `package.json`, already recorded, so a new project starts gated.
 
+### An approval records a version; a denial records a name
+
+`approve` writes `<pkg>@<version>`, pinned to what is installed. `deny` writes the bare name.
+
+- **So an approval goes in after the raise that introduced the version**, or it pins the version
+  being replaced. A denial names no version, so it is decided on its own and in any order.
+- Approve unpinned only where the script is needed whatever the version.
+- **Remove a denial before approving.** `approve` refuses while the entry stands.
+
 ## `--dry-run` answers "does this upgrade add a script?"
 
 Before committing to an upgrade, the question is whether it introduces an install script

--- a/kit/skills/hoc-npm-install-scripts/SKILL.md
+++ b/kit/skills/hoc-npm-install-scripts/SKILL.md
@@ -38,6 +38,10 @@ resting state. Approval is the exception that has to earn itself.
 
 - Reaching the decision means **denying the script and running the project's own checks** —
   its lint, its tests, whatever it runs to know it works. If those pass, the denial stands.
+  - **A native package answers before the suite does.** Where its binary comes from a prebuilt
+    platform package, the script has nothing left to do: check that the platform package's
+    `.node` file is present, that no build directory was produced, and that the module loads
+    when required.
 - **A package's reputation is not evidence.** Widely used, well maintained, and depended on
   by something the project needs are all true of packages whose install scripts do nothing
   this project uses. The question is not whether the package is trustworthy; it is whether

--- a/kit/skills/hoc-npm-publish/SKILL.md
+++ b/kit/skills/hoc-npm-publish/SKILL.md
@@ -20,14 +20,14 @@ So a release is guarded twice.
 
 ## The version bump is the last commit of the release
 
-The package's **own** version is raised only after every change going into that release is
+The package's **own** version is bumped only after every change going into that release is
 done, in the final commit. Two things depend on it.
 
 - **A premature publish fails instead of succeeding.** While the version still matches what
   is already published, the registry rejects the publish as a collision — so a half-finished
-  tree cannot get out by accident. Raise the version early and that protection is gone: any
+  tree cannot get out by accident. Bump the version early and that protection is gone: any
   publish from any intermediate state goes through.
-- **It concentrates the install into one run.** Raising the version means the lockfile
+- **It concentrates the install into one run.** Bumping the version means the lockfile
   has to be updated too, which is the occasion to run the install — once, at the end. The
   dependency tree settles in that one run rather than being shaken through the work.
 
@@ -43,7 +43,7 @@ Update the package version to x.x.x in package-lock.json
   separates a generated artefact from hand-written source. What is specific here is **the
   order and the single install between them.**
 - The bump commit is also the declaration that the release is ready. Reading it in a log
-  means the release is imminent, so do not raise a version to keep a branch tidy.
+  means the release is imminent, so do not bump a version to keep a branch tidy.
 
 ## When the bump turns out not to be last
 
@@ -67,8 +67,8 @@ trunk?**
 When bringing dependencies up to date, edit **one package per commit** in the manifest, and
 commit the lockfile once at the end after a single install.
 
-- The git commit convention already separates a dependency bump from code that uses it. This
-  goes further: **the bumps are separated from each other**, because each one is its own
+- The git commit convention already separates a dependency raise from code that uses it. This
+  goes further: **the raises are separated from each other**, because each one is its own
   risk with its own rollback, and a tree that breaks after ten of them in one commit gives
   no information about which.
 - The lockfile is one commit however many packages moved, since it is generated and

--- a/kit/skills/hoc-npm-vulnerability/SKILL.md
+++ b/kit/skills/hoc-npm-vulnerability/SKILL.md
@@ -81,8 +81,22 @@ it is.**
 - **A key scoped to a major line (`name@major`) touches only that line.** Where two major
   versions of one package are present because different dependants asked for different
   ranges, an unscoped key moves both; the scoped key moves the one the advisory names.
-- Confirm the raised version still satisfies whatever asked for it. An override landing
-  outside a dependant's declared range is a break waiting for the next install.
+- **An override reaches every copy in the tree, at every depth, whatever each dependant
+  declared.** One landing outside a dependant's range is the signal to go and look, not the
+  verdict — measured, an unscoped key carried a dependant across a major it had excluded and
+  nothing broke.
+
+### What decides it is the call site, not the declared range
+
+**Go to the dependant's source and read what it calls.** A range says which version was asked
+for; only the call says whether the version delivered answers.
+
+- **Where the call site survives, leave the key unscoped** and the tree keeps one copy instead
+  of two.
+- **Where it does not, scope the key to the major line the advisory names**, and the
+  out-of-range dependant keeps the release it asked for.
+- **Neither the package's reputation nor the size of the jump settles it.** A major that removed
+  nothing the dependant uses is safe; a minor that changed a default it relies on is not.
 
 ## Check that the fix version itself clears the quarantine
 

--- a/kit/skills/hoc-skill-updating/SKILL.md
+++ b/kit/skills/hoc-skill-updating/SKILL.md
@@ -48,6 +48,61 @@ After the prefix, name the subject, not the source tree:
   convention for moving dependency versions took `raise` rather than `bump` on this ground —
   `bump` heads the publishing convention's rule about a release's own version.
 
+### The name is read as "how to do X"
+
+**A reader expands the name into an instruction.** `hoc-git-commit` reads as how to commit,
+`hoc-npm-publish` as how to publish, and every skill in the libraries is read the same way. So
+**the subject after the prefix has to be a practice**, and the check on a candidate is
+mechanical: expand it and read the result.
+
+**The expansion reads the words in the order they are written.** Two shapes manage it: a verb
+with its object behind it, and an established compound noun — `hoc-code-review` expands to how
+to do a code review without anything being moved. What fails is a name that is neither, whose
+words have to be swapped before the instruction appears. `hoc-npm-deps-raise` was defended as
+*how to raise deps*, which is the name read backwards; `hoc-npm-raise-deps` is the same three
+words in the order that reads. **The swap is easy to perform without noticing**, because whoever
+supplies it already knows what the skill does, and a reader meeting the name in a flat list does
+not.
+
+**Naming a skill after the outcome it exists to prevent inverts it.** A skill written to keep a
+refactor from moving a published interface was proposed as `hoc-breaking-change` — which expands
+to *how to make a breaking change*, instructions for producing the very thing. The argument for
+it was that a person's actual question is "is this a breaking change?", and that a name matching
+the question routes best. It does not survive the expansion: the question a reader arrives with
+and the instruction they leave with are not the same sentence.
+
+- **This does not reach a skill named for a body of rules.** `hof-css-prohibits` expands to how
+  to handle the CSS prohibitions, and observing them is the practice. What fails the test is a
+  name whose subject is a result nobody wants, not one whose subject is a set of rules about
+  results.
+
+**A name must not promise an extent the convention does not reach.** A skill for bringing a
+project's declared dependency versions up was proposed as `hoc-npm-deps-latest`, while the
+convention it carried takes each entry only as far as its own declaration already permits and
+leaves anything past that for a decision of its own. A pass that finishes under it is therefore
+not at the latest of everything: the name promised the one thing the body spends a section
+refusing.
+
+- The fault is not the word but its grammar. **The word states a result where the body states a
+  bound**, so check a candidate against the rule that limits the practice, never against the
+  rule that describes it — the describing rule is what suggested the name in the first place.
+- Where the name has to carry a direction, take a verb that gives one without naming a
+  destination. `raise` says which way and stops there.
+
+**Where the library already has a word for the thing, the name takes that word.** The skill above
+became `hoc-retake-declaration`, from the verb the commit convention defines: a `Retake` replaces
+something poor or hurried with what should have been written and *claims no gain beyond that*,
+where an `Update` carries an implementation forward and the gain is the point.
+
+That name does work a descriptive one cannot. **It decides membership.** Asked whether a defect
+found mid-work may be fixed, the name answers on its own — fixing it is a gain, a gain is an
+`Update`, and this is a `Retake`. A name assembled out of fresh words has to be read alongside
+the body before it settles anything, and a rule the body forgot to state is then simply absent.
+
+- The cost is that the reader must know the word. That is paid once, by the convention that
+  defines it, and it is the same cost the vocabulary was already worth paying — **a term the
+  library defines and never names a skill after is a term nobody meets.**
+
 ## Writing and updating the description
 
 - `description:` should indicate the skill's scope (what subject it covers, and what it defines), not name an individual rule.

--- a/kit/skills/hoc-skill-updating/SKILL.md
+++ b/kit/skills/hoc-skill-updating/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-skill-updating
-description: "Conventions for creating new skills (SKILL.md) or updating existing ones. Defines how to name a skill (the domain prefix, and the folder name that must equal `name:`), where the folder goes among the three domain directories, and the conventions to follow when writing the body and the description."
+description: "Conventions for creating new skills (SKILL.md) or updating existing ones. Defines how to name a skill (the prefix its library owns, the folder name that must equal `name:`, and the practice the rest of the name has to state), which library repository a skill belongs to, where one skill stops and a neighbouring convention takes over, the flat layout every library keeps under `kit/skills/`, and the conventions to follow when writing the body and the description."
 ---
 
 # Skill Updating

--- a/kit/skills/hoc-skill-updating/SKILL.md
+++ b/kit/skills/hoc-skill-updating/SKILL.md
@@ -15,23 +15,25 @@ This gathers the conventions for creating new skills (`SKILL.md`) or updating ex
 skill's own folder name and the folder name it installs as. **One string, three places.** Choose it
 for the reader who sees a flat list of skills and never sees this repository.
 
-- **The name begins with its domain's prefix**: `hoc-` for a skill under `core/`, `hor-` under
-  `backend/`, `hof-` under `frontend/`. The prefix is what tells a reader of that flat list which
-  skills came from this library, and which domain each belongs to.
+- **The name begins with its library's prefix.** Each library repository owns one prefix, and the
+  prefix is what tells a reader of that flat list which library a skill came from. Deciding which
+  library a skill belongs to and deciding the first characters of its name are one decision, taken
+  once — see the placement section below.
 - **`name:` and the folder name must be the same string.** They are not two facts to keep in sync
   by habit: the build that produces the installable output and the repository's skill-name audit
   both refuse to proceed on a mismatch.
-- **The name is 4–64 characters of `[a-z0-9-]`**, of which the prefix takes 3. A single case only.
-- **Uniqueness needs no thought.** One directory cannot hold two folders of one name, and the three
-  prefixes cannot overlap, so no two skills in the library can collide.
+- **The name is 4–64 characters of `[a-z0-9-]`**, of which the prefix takes the first three or
+  four. A single case only.
+- **Uniqueness needs no thought.** One directory cannot hold two folders of one name, and no two
+  libraries share a prefix, so no two skills across the libraries can collide.
 - **Renaming is a breaking change** for repositories that already invoke the skill, so choose
-  deliberately the first time. Moving a skill to another domain is a rename too — the prefix
+  deliberately the first time. Moving a skill to another library is a rename too — the prefix
   changes with it.
 
 After the prefix, name the subject, not the source tree:
 
-- **Leave out words that only place the skill within its domain.** A backend skill does not repeat
-  the framework it is for, and a `core` skill does not carry a classifying word like
+- **Leave out words that only repeat what the prefix already says.** A backend skill does not
+  restate the framework it is for, and a foundational skill does not carry a classifying word like
   `declarations`, `shared` or `members` — `hoc-async`, `hoc-accessors`, `hor-agent-loop`.
 - **Keep a classifying word when it is what a reader would search for**: `hoc-classes-constructor`,
   `hoc-modules-exports`, `hof-css-units`.
@@ -43,7 +45,7 @@ After the prefix, name the subject, not the source tree:
 
 ## Writing and updating the description
 
-- `description:` should indicate the skill's scope (which domain, and what it defines), not name an individual rule.
+- `description:` should indicate the skill's scope (what subject it covers, and what it defines), not name an individual rule.
 - When a skill is updated (rules added or removed), update `description:` to reflect what was added or removed. Do not let `description:` go stale by changing only the body.
 
 ### Keep the description under 500 characters
@@ -51,7 +53,7 @@ After the prefix, name the subject, not the source tree:
 - **Every description is loaded into every conversation**, whether the skill is used or not, because the agent needs them to route. The cost is paid up front by all users of the library, so a description is not free space.
 - **Never summarize the procedure in the description.** A description complete enough to act on gets acted on *instead of* the skill: it is already in context, and opening `SKILL.md` is an extra step the agent can skip. A skill that says "run three passes" in its body but "reviews correctness and conventions" in its description will get one pass.
 - Do not enumerate the body's sections, steps, checks, or file layout. That is a table of contents, and it belongs in the body.
-- Write only what decides routing: **scope** (domain, and what kind of artifact), **triggers** (the words and situations that should reach this skill), and the **boundary** (what this skill is not, and which convention owns that instead). What discriminates between sibling skills is the boundary, never the list of internal checks — siblings share those.
+- Write only what decides routing: **scope** (the subject, and what kind of artifact), **triggers** (the words and situations that should reach this skill), and the **boundary** (what this skill is not, and which convention owns that instead). What discriminates between sibling skills is the boundary, never the list of internal checks — siblings share those.
 - 500 characters is the ceiling, not the target. Most skills route correctly in 250–400. Length is a proxy: if the description is long, it is almost always because it started summarizing the procedure.
 - Refer to a neighbouring convention descriptively ("input validation belongs to the resolver input-validator convention"), never by path.
 - Quote the value (`description: "..."`) or use a block scalar (`description: |-`). A bare scalar containing `: ` is not valid YAML and the frontmatter will fail to parse.
@@ -63,26 +65,42 @@ After the prefix, name the subject, not the source tree:
   executable helpers under `scripts/`.
 - A skill directory holds no `SKILL.md` below its own top level. Its subdirectories are its own
   files, never more skills.
-- There are exactly three domain directories, and a skill folder sits **directly** inside one of
-  them — one level, with no grouping directories in between:
+- **`kit/skills/` is flat.** A skill folder sits directly inside it, and there is no level in
+  between:
 
 ```
-lib/skills/
-├── core/      hoc-*   Common/foundational (conventions applied across backend/frontend)
-├── backend/   hor-*   Backend-specific
-└── frontend/  hof-*   Frontend-specific
+kit/skills/
+├── <name>/
+│   ├── SKILL.md
+│   ├── references/
+│   └── scripts/
+└── <another-name>/
+    └── SKILL.md
 ```
 
-So every skill in the library is at `lib/skills/<domain>/<name>/SKILL.md`, and nowhere else. There
-is no `backend/<framework>/`, no `frontend/<library>/components/`: what a nested directory would
-have said belongs in the name instead, where the reader of an installed skill can see it.
+So every skill is at `kit/skills/<name>/SKILL.md`, and nowhere else. There is no grouping
+directory for a framework, a component family or a category: what such a directory would have
+said belongs in the name instead, where the reader of an installed skill can see it. **An
+installed skill has no directory above it either** — skills arrive as siblings under
+`.claude/skills/`, so a layer the source tree keeps is a layer that does not survive shipping.
 
 ## Placement of skills
 
-- Common conventions that do not depend on a specific domain go under `core/`.
-- Conventions specific to a particular domain go under that domain's directory.
-- The prefix must match the directory. Deciding the domain and deciding the first three characters
-  of the name are the same decision.
+**A skill belongs to one library repository, and the library is what its prefix names.** There is
+no directory to choose: the repository is the choice, and the flat `kit/skills/` below it holds
+whatever that repository carries.
+
+- Conventions that hold whatever is being built go to the foundational library.
+- Conventions that only make sense within one stack, platform or product go to that library.
+- Conventions about how work is carried out and handed over — writing a document, an issue, a
+  manual — go to the support library.
+- **The prefix must match the library.** Deciding which library a skill belongs to and deciding
+  the first characters of its name are the same decision, and getting it wrong later costs a
+  rename.
+
+**A subject that spans two libraries is two skills, not one.** One prefix cannot name two
+libraries, so there is no name a single skill could take. Split it where the libraries divide,
+and let each half name the other by name where a reader has to go there.
 
 ## Keep skills self-contained
 

--- a/kit/skills/hoc-skill-updating/SKILL.md
+++ b/kit/skills/hoc-skill-updating/SKILL.md
@@ -42,6 +42,11 @@ After the prefix, name the subject, not the source tree:
 - **One word after the prefix is enough when it names the concept unambiguously** (`hoc-async`,
   `hoc-jest`). Qualify it when sibling skills have an equal claim to the same word: CSS prohibitions
   are `hof-css-prohibits` and `hof-css-props-prohibits`, not two skills both called prohibits.
+- **A word another convention already leads with is not freed by qualifying it.** Qualification
+  settles siblings that hold a word equally; where one convention has built its own rule on the
+  word, a second skill carrying it leaves the word pointing at two places and naming neither. A
+  convention for moving dependency versions took `raise` rather than `bump` on this ground —
+  `bump` heads the publishing convention's rule about a release's own version.
 
 ## Writing and updating the description
 

--- a/kit/skills/hoc-skill-updating/SKILL.md
+++ b/kit/skills/hoc-skill-updating/SKILL.md
@@ -162,6 +162,42 @@ whatever that repository carries.
 libraries, so there is no name a single skill could take. Split it where the libraries divide,
 and let each half name the other by name where a reader has to go there.
 
+## Where a skill stops
+
+A `description:` that names its boundary has said where the skill stops. **It has not said when
+the reader gets there**, and that missing sentence is what lets the neighbour's material back in.
+
+**Naming a boundary does not discharge it.** A convention that routed advisories next door in its
+opening paragraph still carried the neighbouring mechanism through its body — the reach of an
+override, the test for whether a consumer survives one — in wording that was nearly the
+neighbour's own. The boundary was written and the body walked past it, because nothing in the
+body said at which point the reader leaves.
+
+**A rule whose reason lives in another convention is that convention's rule.** The test is not
+whether the rule is true, nor whether readers of this skill will meet the situation. It is
+whether *this* convention supplies the reason the rule exists. The skill above had a row sending
+a dependency the project never asked for to an override, and said nowhere why such a dependency
+would move at all; the only reason the library gives for moving one is an advisory, which belongs
+next door. **A rule supported from outside is a rule that belongs outside.**
+
+- This is what a duplicate looks like before it becomes one. Two skills stating a rule in nearly
+  the same words is the late symptom. The early symptom is a rule sitting in a skill that cannot
+  say why it is there.
+
+**Specify the handoff by what this convention could not reach.** A boundary written as a subject
+— *advisories belong next door* — leaves the reader to judge when a subject has arrived. A
+boundary written as a residue does not: run the convention to its end, and whatever is left is
+the neighbour's by construction. The dependency convention hands on what the audit still reports
+**after** its pass, which is exactly what raising a declared version could not reach, and that is
+also the case the neighbouring convention opens with. The two halves meet without either
+restating the other.
+
+- The residue is usually the neighbour's own opening case. Where it is not, the boundary is in
+  the wrong place.
+- **A convention that mostly clears what the neighbour handles still needs the sentence.** Stating
+  what the practice *adds* gets the direction backwards, and sends the reader next door for the
+  cases the practice was about to settle itself.
+
 ## Keep skills self-contained
 
 - Write a skill so that it is meaningfully complete on its own. **Information that is not self-contained within the skill must not be put into `SKILL.md`.**

--- a/kit/skills/hoc-test-execution/SKILL.md
+++ b/kit/skills/hoc-test-execution/SKILL.md
@@ -2,11 +2,10 @@
 name: hoc-test-execution
 description: >
   Run a project's test cases and drive them to green without weakening them — no test skipped,
-  deleted, loosened, or padded with waits to make the suite pass. Use this skill whenever tests are run,
-  whenever a test still fails after an implementation was believed finished, when the user asks to
-  run or fix failing tests, and before claiming an implementation is complete. Writing new tests
-  belongs to the project's test-writing convention; reusing a recorded pass over unchanged inputs,
-  to the test-cache convention.
+  deleted or loosened to make the suite pass. Use this skill whenever tests are run, whenever a
+  test still fails after an implementation was believed finished, and before claiming an
+  implementation is complete. Writing new tests belongs to the project's test-writing convention;
+  reusing a recorded pass over unchanged inputs, to the test-cache convention.
 ---
 
 # Test Execution

--- a/kit/skills/hoc-workflows/SKILL.md
+++ b/kit/skills/hoc-workflows/SKILL.md
@@ -100,3 +100,21 @@ against 431.
 - **This is the general form of rules stated elsewhere in narrower terms** — that a test is run
   against the unchanged code first, and that progress is recorded from evidence rather than from
   effort. Both are this check applied to one instrument.
+
+### A count belongs to the state it was taken from
+
+**The instrument can be sound and the number still wrong, because the tree moved under it.**
+Counting, then editing, then reporting the earlier count describes a state that no longer exists
+— and nothing in the output betrays it, since the count was correct at the moment it was taken.
+
+Measured: a search reporting that a term was gone was quoted in a report written after two
+further edits had put the term back, twice. The search had run, had run correctly, and had run
+before the change it was being cited about.
+
+- **Take the count after the last edit, not after the edit that prompted it.** The prompting edit
+  is the one that comes to mind, and it is rarely the last one — least of all when the later edits
+  were the ones adding back what was being counted.
+- **A number carried across a turn is a claim about the past.** Either re-take it, or say when it
+  was taken. A bare figure is read as current, because every other figure in a report is.
+- **This failure survives the check above.** Planting a defect proves the instrument moves; it
+  says nothing about which state the instrument was pointed at.

--- a/kit/skills/hoc-workflows/SKILL.md
+++ b/kit/skills/hoc-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-workflows
-description: "Development workflow procedural rules. Defines how to proceed with implementation and the steps that must always be performed before committing / before completion."
+description: "Development workflow procedural rules. Defines how to proceed with implementation, the steps that must always be performed before committing and before completion, and how to establish that a tool reporting nothing was actually measuring. Use when starting an implementation, before a commit, and before calling work complete."
 ---
 
 # Workflows
@@ -45,3 +45,37 @@ Procedural rules related to the development workflow.
   implementation complete while either one is failing.
 - The branch structure the commits land on is decided here, once the work is complete, rather
   than before it starts; see the git branch convention.
+
+## A command that ran is not a command that worked
+
+**A zero comes out of two states: nothing was wrong, and nothing was measured.** The output reads
+the same either way — no findings, no failures, a clean exit — and every gate above is read off
+exactly that.
+
+**So before believing a zero, make the tool report a failure it cannot miss.** Plant a defect of
+the kind it exists to catch, confirm it appears, and take it back out. A count that cannot be made
+to move is not a count.
+
+Measured on a type-checker invoked through a variable holding its flags: the run reported no errors
+before a refactor and none after it, and the conclusion drawn was that the refactor had cost
+nothing. The tool had not run at all. What exposed it was an earlier recorded run over the same
+files at 435 errors — **a zero that contradicts a number somebody wrote down is the only kind that
+announces itself.** Re-measured with the flags written out, the same comparison came back 435
+against 431.
+
+- **A variable holding a command and its flags is one command name, not a command with
+  arguments.** A shell that does not word-split an unquoted parameter looks for a program whose
+  name contains the spaces and the dashes; measured side by side, the identical script ran the
+  command under one shell and reported `command not found` under another. **A variable may hold a
+  path or a filename. It may not hold the command.**
+  - Wrapped in `> file 2>&1 || true`, that failure lands in the output file and the exit status is
+    discarded, so the `grep -c` that reads the file afterwards returns a clean zero. **The error
+    message is inside the file being counted and does not match what is being counted for.**
+- **Reaching the end of a script is not evidence that its steps succeeded.** An abort-on-error
+  setting is not a substitute for looking: a command joined by `||`, one inside a condition, one
+  on the left of `&&` are all outside its reach, and a `|| true` written to keep a step quiet
+  removes it on purpose. **Check the end state the steps were supposed to produce**, not the fact
+  that the script finished.
+- **This is the general form of rules stated elsewhere in narrower terms** — that a test is run
+  against the unchanged code first, and that progress is recorded from evidence rather than from
+  effort. Both are this check applied to one instrument.

--- a/kit/skills/hoc-workflows/SKILL.md
+++ b/kit/skills/hoc-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hoc-workflows
-description: "Development workflow procedural rules. Defines how to proceed with implementation, the steps that must always be performed before committing and before completion, and how to establish that a tool reporting nothing was actually measuring. Use when starting an implementation, before a commit, and before calling work complete."
+description: "Development workflow procedural rules. Defines how to proceed with implementation, the steps that must always be performed before committing and before completion, how to establish that a tool reporting nothing was actually measuring, and what a report of remaining work lists. Use when starting an implementation, before a commit, and before calling work complete."
 ---
 
 # Workflows
@@ -45,6 +45,27 @@ Procedural rules related to the development workflow.
   implementation complete while either one is failing.
 - The branch structure the commits land on is decided here, once the work is complete, rather
   than before it starts; see the git branch convention.
+
+## What is outstanding, and what only looks it
+
+**A report of what is left lists work nobody has started.** Plenty of things read as loose ends
+without being work: a tree holding modified files, a host carrying the issues and pull requests
+this work produced. Neither waits on anybody.
+
+- **Uncommitted changes are not outstanding work.** Whether to commit, and how to split what is
+  in the tree, is a decision of its own. What was written gets reported once, when the work that
+  wrote it is done — carrying it forward on every later report turns a finished piece into a
+  standing debt, and buries the one line that was actually still open.
+- **What was done on the host is not outstanding work either.** An issue filed, a pull request
+  opened, a field edited: asked for, performed, finished. A report that keeps naming them is
+  holding somebody else's queue on their behalf.
+- **What does belong is inert until somebody acts** — a command not yet run, a decision waiting
+  on an answer, a piece deliberately left for later. The test is not whether it is unfinished. It
+  is whether anything happens if nobody picks it up.
+
+**This is the same shape as the rule keeping an automated check off a checklist.** A suite that
+runs itself, a commit somebody else will make, a review somebody else will give — none of them
+wait on whoever is reporting, and naming them tells the reader nothing they did not already have.
 
 ## A command that ran is not a command that worked
 


### PR DESCRIPTION
# Why

* Close #90

# How

## One line first, then split by convention

The rules were written and committed as they were settled, and the branch structure was cut from
the finished line afterwards rather than chosen in advance. Each convention took a sub-branch of
its own and returned with `--no-ff`, so eleven merge commits each name one convention and the
diff reads a skill at a time instead of as a single thirty-commit run.

Part of the material arrived as untitled snapshot commits holding several files at once. Those
were re-split by decision rather than by file: where one file carried two unrelated rules, the
split was made by hunk, so every commit carries one rule and its subject says which. The result
was checked against the snapshot tree rather than assumed — every path lands byte-identical.

## Cheapest first, largest last

The sub-branches merge in ascending size, so `/hoc-skill-updating` and `/hoc-git-branch` sit at
the top of the log where a reader starts and reads hardest, and the one-line description updates
sit at the bottom where they cost nothing to pass over.

## The verb split is carried in both conventions at once

`/hoc-npm-publish` and `/hoc-git-commit` both used `bump` for a dependency's version and for the
package's own. Moving one and leaving the other would leave two conventions contradicting each
other inside the same release, so both moved here rather than one now and one later.

# Note

* `author/skills` is cut from this branch and carries `/hoc-eslint-config` and
  `/hoc-retake-declaration` (#91). It opens after this one merges, rebased onto the new tip of
  `release/0.4.0`.
* `/hoc-skill-updating` now describes one library per repository in place of the three domain
  directories. It records a layout this repository already has — nothing moves here.
